### PR TITLE
Add JSON data for 13 missing fruits and 11 missing vegetables.

### DIFF
--- a/src/lib/data/fruits/blackcurrant.json
+++ b/src/lib/data/fruits/blackcurrant.json
@@ -1,0 +1,198 @@
+{
+  "id": "blackcurrant",
+  "commonName": "Blackcurrant",
+  "scientificName": "Ribes nigrum",
+  "image": "https://www.rhs.org.uk/getmedia/1f825c8a-7526-40a1-9883-4618e7395508/Ribes-nigrum-Ben-Sarek-fruit.jpg",
+  "description": "The blackcurrant (Ribes nigrum), also known as black currant or cassis, is a deciduous shrub in the family Grossulariaceae grown for its edible berries. It is native to temperate parts of central and northern Europe and northern Asia, where it prefers damp fertile soils and is widely cultivated.",
+  "origin": "Northern Europe and Northern Asia",
+  "localNames": [
+    "Cassis (French)",
+    "Schwarze Johannisbeere (German)",
+    "Чёрная смородина (Russian)",
+    "Grosella negra (Spanish)"
+  ],
+  "regions": [
+    "Europe (especially Poland, UK, Germany, France)",
+    "New Zealand",
+    "Russia",
+    "Parts of Asia",
+    "North America (limited)"
+  ],
+  "seasons": [
+    "Summer (typically June to August in the Northern Hemisphere)"
+  ],
+  "nutrition": {
+    "calories": "63 kcal per 100g",
+    "macronutrients": [
+      {
+        "name": "Protein",
+        "value": 1.4,
+        "unit": "g"
+      },
+      {
+        "name": "Carbohydrates",
+        "value": 15.4,
+        "unit": "g"
+      },
+      {
+        "name": "Fat",
+        "value": 0.4,
+        "unit": "g"
+      },
+      {
+        "name": "Fiber",
+        "value": 4.8,
+        "unit": "g"
+      }
+    ],
+    "vitamins": [
+      {
+        "name": "Vitamin C",
+        "value": 181,
+        "unit": "mg",
+        "rdi": "201%"
+      },
+      {
+        "name": "Vitamin E",
+        "value": 1.0,
+        "unit": "mg",
+        "rdi": "7%"
+      },
+      {
+        "name": "Vitamin A",
+        "value": 12,
+        "unit": "µg",
+        "rdi": "1%"
+      },
+      {
+        "name": "Vitamin K",
+        "value": 0.3, 
+        "unit": "µg",
+        "rdi": "0%" 
+      },
+      {
+        "name": "Thiamin (B1)",
+        "value": 0.05,
+        "unit": "mg",
+        "rdi": "4%"
+      },
+      {
+        "name": "Riboflavin (B2)",
+        "value": 0.05,
+        "unit": "mg",
+        "rdi": "4%"
+      },
+      {
+        "name": "Niacin (B3)",
+        "value": 0.3,
+        "unit": "mg",
+        "rdi": "2%"
+      },
+      {
+        "name": "Pantothenic acid (B5)",
+        "value": 0.398,
+        "unit": "mg",
+        "rdi": "8%"
+      },
+      {
+        "name": "Vitamin B6",
+        "value": 0.066,
+        "unit": "mg",
+        "rdi": "4%"
+      }
+    ],
+    "minerals": [
+      {
+        "name": "Potassium",
+        "value": 322,
+        "unit": "mg",
+        "rdi": "9%"
+      },
+      {
+        "name": "Manganese",
+        "value": 0.256,
+        "unit": "mg",
+        "rdi": "11%"
+      },
+      {
+        "name": "Iron",
+        "value": 1.54,
+        "unit": "mg",
+        "rdi": "9%"
+      },
+      {
+        "name": "Calcium",
+        "value": 55,
+        "unit": "mg",
+        "rdi": "5%"
+      },
+      {
+        "name": "Magnesium",
+        "value": 24,
+        "unit": "mg",
+        "rdi": "6%"
+      },
+      {
+        "name": "Phosphorus",
+        "value": 59,
+        "unit": "mg",
+        "rdi": "5%"
+      },
+      {
+        "name": "Copper",
+        "value": 0.089,
+        "unit": "mg",
+        "rdi": "10%"
+      },
+      {
+        "name": "Zinc",
+        "value": 0.27,
+        "unit": "mg",
+        "rdi": "2%"
+      }
+    ]
+  },
+  "healthBenefits": [
+    "Extremely rich in Vitamin C, significantly boosting the immune system and acting as a powerful antioxidant.",
+    "Contains high levels of anthocyanins and other polyphenols, which have antioxidant and anti-inflammatory effects, protecting against chronic diseases.",
+    "Good source of dietary fiber, which aids digestion, promotes gut health, and can help regulate blood sugar levels."
+  ],
+  "potentialAllergies": [
+    {
+      "name": "Oral Allergy Syndrome (OAS)",
+      "severity": "Mild",
+      "details": "Rare, but individuals with birch pollen allergies might experience OAS. Symptoms are usually mild and include itching or swelling of the mouth, lips, tongue, and throat after consuming raw blackcurrants."
+    }
+  ],
+  "cultivationProcess": "Blackcurrants are hardy deciduous shrubs that prefer cool, moist climates and well-drained, fertile soil with a slightly acidic to neutral pH. They are typically propagated from cuttings or purchased as young bushes. Planting is best done in autumn or winter. Bushes require regular pruning to remove old, unproductive wood and encourage new growth, as fruit is primarily borne on one-year-old shoots. They need consistent watering, especially during fruit development, and benefit from mulching and appropriate fertilization.",
+  "growthDuration": "Bushes usually start producing a small crop 1-2 years after planting, with significant yields typically from year 3 or 4. Fruits ripen in mid-summer, about 90-110 days after flowering, depending on the cultivar and climate.",
+  "sustainabilityTips": [
+    "Choose locally grown blackcurrants when in season to minimize food miles and support local agriculture.",
+    "Preserve excess blackcurrants by freezing, canning, or making jams/jellies to reduce food waste and enjoy them year-round."
+  ],
+  "carbonFootprintInfo": "The carbon footprint of fresh blackcurrants is relatively low when sourced locally and in season. However, processing (e.g., for juices, concentrates) and long-distance transportation (especially air freight for fresh berries out of season) can significantly increase their environmental impact.",
+  "staticRecipes": [
+    {
+      "name": "Simple Blackcurrant Jam",
+      "description": "A classic, easy-to-make jam that captures the deliciously tart and intense flavor of fresh blackcurrants. Perfect on toast, scones, or with yogurt.",
+      "ingredients": [
+        "500g fresh blackcurrants, rinsed and stems removed",
+        "500g granulated sugar",
+        "Juice of 1/2 lemon (optional, aids setting and brightens flavor)",
+        "25ml water (if not using lemon juice)"
+      ],
+      "steps": [
+        "Combine the blackcurrants and water (or lemon juice) in a large, heavy-bottomed saucepan.",
+        "Simmer gently over medium-low heat for 15-20 minutes, or until the blackcurrant skins are very soft and have started to burst. Stir occasionally.",
+        "Add the sugar to the saucepan. Stir continuously over low heat until the sugar has completely dissolved. Do not let the mixture boil at this stage.",
+        "Once the sugar is dissolved, increase the heat to high and bring the mixture to a rolling boil (a boil that continues even when you stir it).",
+        "Boil rapidly for 10-15 minutes. Stir frequently to prevent the jam from sticking to the bottom of the pan.",
+        "Test for setting point: Place a small spoonful of jam onto a chilled saucer, let it cool for 30 seconds, then push it with your finger. If it wrinkles, it's set. Alternatively, use a jam thermometer – setting point is 105°C (221°F).",
+        "Once setting point is reached, remove the saucepan from the heat. Skim off any foam/scum from the surface using a slotted spoon.",
+        "Let the jam sit for about 10-15 minutes to cool slightly; this helps prevent the fruit from floating in the jars.",
+        "Carefully pour the hot jam into warm, sterilized jars, leaving about 1cm headspace. Seal the jars tightly while hot.",
+        "Allow the jars to cool completely. Label and store in a cool, dark, dry place. Refrigerate after opening."
+      ]
+    }
+  ]
+}

--- a/src/lib/data/fruits/gooseberry.json
+++ b/src/lib/data/fruits/gooseberry.json
@@ -1,0 +1,156 @@
+{
+  "id": "gooseberry",
+  "commonName": "Gooseberry",
+  "scientificName": "Ribes uva-crispa",
+  "image": "https://upload.wikimedia.org/wikipedia/commons/3/36/Stachelbeeren.jpg",
+  "description": "Gooseberries are tart to sweet-tart berries, typically green, red, or yellow, belonging to the Ribes genus. They are known for their distinct flavor and are used in desserts, jams, and sauces. The berries can be smooth or hairy depending on the variety.",
+  "origin": "Native to Europe, northwestern Africa, and western, southern, and southeastern Asia.",
+  "localNames": [
+    "Fea-berry (Old English)",
+    "Groseille à maquereau (French)",
+    "Stachelbeere (German)"
+  ],
+  "regions": [
+    "Europe (United Kingdom, Germany, France, Poland, Scandinavia)",
+    "North America (USA, Canada - cultivation limited in some areas due to rust concerns)",
+    "Asia (parts of temperate Asia)"
+  ],
+  "seasons": [
+    "Late spring to mid-summer (typically May to August in the Northern Hemisphere)"
+  ],
+  "nutrition": {
+    "calories": "44 kcal per 100g",
+    "macronutrients": [
+      {
+        "name": "Protein",
+        "value": 0.88,
+        "unit": "g"
+      },
+      {
+        "name": "Carbohydrates",
+        "value": 10.18,
+        "unit": "g"
+      },
+      {
+        "name": "Fat",
+        "value": 0.58,
+        "unit": "g"
+      },
+      {
+        "name": "Fiber",
+        "value": 4.3,
+        "unit": "g"
+      }
+    ],
+    "vitamins": [
+      {
+        "name": "Vitamin C",
+        "value": 27.7,
+        "unit": "mg",
+        "rdi": "31%"
+      },
+      {
+        "name": "Vitamin A",
+        "value": 12,
+        "unit": "µg",
+        "rdi": "1%"
+      },
+      {
+        "name": "Vitamin K",
+        "value": 10,
+        "unit": "µg",
+        "rdi": "8%"
+      },
+      {
+        "name": "Vitamin B6",
+        "value": 0.026,
+        "unit": "mg",
+        "rdi": "2%"
+      }
+    ],
+    "minerals": [
+      {
+        "name": "Potassium",
+        "value": 198,
+        "unit": "mg",
+        "rdi": "4%"
+      },
+      {
+        "name": "Manganese",
+        "value": 0.144,
+        "unit": "mg",
+        "rdi": "6%"
+      },
+      {
+        "name": "Copper",
+        "value": 0.068,
+        "unit": "mg",
+        "rdi": "8%"
+      },
+      {
+        "name": "Phosphorus",
+        "value": 27,
+        "unit": "mg",
+        "rdi": "2%"
+      },
+      {
+        "name": "Calcium",
+        "value": 25,
+        "unit": "mg",
+        "rdi": "2%"
+      },
+      {
+        "name": "Iron",
+        "value": 0.31,
+        "unit": "mg",
+        "rdi": "2%"
+      },
+      {
+        "name": "Magnesium",
+        "value": 10,
+        "unit": "mg",
+        "rdi": "2%"
+      }
+    ]
+  },
+  "healthBenefits": [
+    "Rich in Vitamin C, a potent antioxidant supporting immune function and collagen production.",
+    "Good source of dietary fiber, promoting digestive health and helping to regulate blood sugar levels.",
+    "Contain various phytonutrients and flavonoids, which may contribute to overall health through their antioxidant properties."
+  ],
+  "potentialAllergies": [
+    {
+      "name": "Salicylate sensitivity (rare)",
+      "severity": "Mild",
+      "details": "Individuals sensitive to salicylates might experience reactions. The tiny hairs on some varieties can be a skin irritant for some people during handling."
+    }
+  ],
+  "cultivationProcess": "Gooseberry plants are hardy, deciduous shrubs that thrive in cool, moist temperate climates. They prefer well-drained, loamy soil with good air circulation. Propagation is commonly done through hardwood cuttings taken in autumn or softwood cuttings in summer. Plants require regular pruning to maintain an open, goblet shape, encourage fruit production on young wood (1-3 year old spurs), and improve air circulation to reduce disease risk. They are susceptible to pests like gooseberry sawfly and diseases such as American gooseberry mildew and white pine blister rust (in North America).",
+  "growthDuration": "Gooseberry bushes typically start bearing fruit 1-2 years after planting from cuttings, reaching full productivity within 3-5 years. Fruits ripen in early to mid-summer, depending on the cultivar and local climate.",
+  "sustainabilityTips": [
+    "Plant disease-resistant cultivars to minimize the need for chemical sprays.",
+    "Mulch around the base of bushes to conserve soil moisture, suppress weeds, and regulate soil temperature."
+  ],
+  "carbonFootprintInfo": "Locally grown gooseberries picked in season have a relatively low carbon footprint. Gooseberries imported from distant regions, especially if air-freighted when out of season, will have a significantly higher environmental impact due to transportation and potential refrigeration.",
+  "staticRecipes": [
+    {
+      "name": "Classic Gooseberry Fool",
+      "description": "A simple and traditional English dessert that beautifully balances the tartness of cooked gooseberries with the sweetness and creaminess of custard or whipped cream.",
+      "ingredients": [
+        "500g fresh gooseberries, topped and tailed (ends removed)",
+        "100g granulated sugar (or more, to taste)",
+        "2 tablespoons water",
+        "300ml double cream (heavy cream) or thick vanilla custard (store-bought or homemade)"
+      ],
+      "steps": [
+        "Place the prepared gooseberries, sugar, and water into a medium saucepan.",
+        "Cook over low to medium heat, stirring occasionally, until the sugar has dissolved and the gooseberries have softened and started to burst, becoming pulpy. This usually takes about 10-15 minutes.",
+        "Remove from heat and taste the gooseberry compote. Add more sugar if it's too tart for your liking. Allow the mixture to cool completely.",
+        "If using double cream, pour it into a chilled bowl and whip it using an electric mixer or whisk until it forms soft, billowy peaks. Be careful not to overwhip.",
+        "Once the gooseberry compote is completely cool, gently fold it into the whipped cream or thick custard. Aim for a marbled effect, with streaks of fruit and cream/custard, rather than mixing it uniformly.",
+        "Spoon the gooseberry fool into individual serving glasses or a larger serving bowl.",
+        "Chill in the refrigerator for at least 1 hour before serving to allow the flavors to meld and the dessert to set further. Serve cold."
+      ]
+    }
+  ]
+}

--- a/src/lib/data/fruits/karonda.json
+++ b/src/lib/data/fruits/karonda.json
@@ -1,0 +1,136 @@
+{
+  "id": "karonda",
+  "commonName": "Karonda",
+  "scientificName": "Carissa carandas",
+  "image": "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9e/Carissa_carandas_fruit_at_tree.jpg/1024px-Carissa_carandas_fruit_at_tree.jpg",
+  "description": "Karonda (Carissa carandas) is a hardy, drought-tolerant shrub that produces small, berry-sized fruits. The fruits are green when unripe, turning to a rich dark purple or black when ripe, and are known for their distinctly tart to sweet-sour flavor. They are widely used in Indian pickles, chutneys, jams, and sometimes as a substitute for cranberries.",
+  "origin": "Indian subcontinent and Southeast Asia",
+  "localNames": [
+    "Bengal Currant (English)",
+    "Christ's Thorn (English)",
+    "Karvand (Marathi)",
+    "Karamcha (Bengali)",
+    "Kalakai (Tamil)",
+    "Karau(n)da (Hindi)"
+  ],
+  "regions": [
+    "India (widely across states like Maharashtra, Goa, Karnataka, Rajasthan, Gujarat, Bihar, West Bengal, Uttar Pradesh)",
+    "Nepal",
+    "Sri Lanka",
+    "Pakistan",
+    "Bangladesh",
+    "Afghanistan",
+    "Myanmar",
+    "Malaysia",
+    "Indonesia"
+  ],
+  "seasons": [
+    "Rainy season to early autumn (typically July to September in India and surrounding regions)"
+  ],
+  "nutrition": {
+    "calories": "71 kcal per 100g",
+    "macronutrients": [
+      {
+        "name": "Protein",
+        "value": 1.0,
+        "unit": "g"
+      },
+      {
+        "name": "Carbohydrates",
+        "value": 16.5,
+        "unit": "g"
+      },
+      {
+        "name": "Fat",
+        "value": 2.9,
+        "unit": "g"
+      },
+      {
+        "name": "Fiber",
+        "value": 1.8,
+        "unit": "g"
+      }
+    ],
+    "vitamins": [
+      {
+        "name": "Vitamin C",
+        "value": 10,
+        "unit": "mg",
+        "rdi": "11%"
+      },
+      {
+        "name": "Vitamin A",
+        "value": 6,
+        "unit": "µg",
+        "rdi": "1%"
+      }
+    ],
+    "minerals": [
+      {
+        "name": "Iron",
+        "value": 1.5,
+        "unit": "mg",
+        "rdi": "8%"
+      },
+      {
+        "name": "Calcium",
+        "value": 25,
+        "unit": "mg",
+        "rdi": "2%"
+      },
+      {
+        "name": "Phosphorus",
+        "value": 28,
+        "unit": "mg",
+        "rdi": "4%"
+      }
+    ]
+  },
+  "healthBenefits": [
+    "Good source of Vitamin C, an antioxidant that boosts the immune system and supports skin health.",
+    "Traditionally valued for its iron content, believed to help in managing anemia.",
+    "Used in Ayurvedic medicine for digestive ailments, and its tartness can stimulate appetite."
+  ],
+  "potentialAllergies": [
+    {
+      "name": "Latex sensitivity (rare)",
+      "severity": "Mild",
+      "details": "The plant and unripe fruits exude a latex which could be an irritant for individuals with latex sensitivity. Generally, ripe fruits are well-tolerated when cooked or pickled."
+    }
+  ],
+  "cultivationProcess": "Karonda is a very hardy, drought-tolerant, and resilient shrub that can grow in a wide range of soils, including marginal and wasteland areas. It's often propagated from seeds sown during the monsoon season (August-September) or vegetatively through budding or inarching. The plant is thorny and grows rapidly, making it suitable for use as a protective hedge. It requires minimal care once established.",
+  "growthDuration": "Plants grown from seed typically begin to bear fruit within 2-3 years of planting. Flowering usually occurs in March, and fruits ripen from July to September in Northern India.",
+  "sustainabilityTips": [
+    "Its hardy and drought-tolerant nature makes it an excellent crop for arid and semi-arid regions, requiring less water than many other fruit crops.",
+    "Can be grown as a live fence or hedge, providing fruit as well as acting as a natural barrier and habitat for small wildlife."
+  ],
+  "carbonFootprintInfo": "Karonda grown locally, especially in regions where it thrives with minimal agricultural inputs (like parts of India), has a low carbon footprint. Its hardiness reduces the need for intensive farming practices. Transportation to distant markets would be the primary contributor to its carbon footprint.",
+  "staticRecipes": [
+    {
+      "name": "Spicy Karonda Pickle (Karvand Achar)",
+      "description": "A traditional Indian pickle made from tart karonda berries, celebrated for its spicy, tangy, and slightly sweet flavor. It's a popular condiment served with meals.",
+      "ingredients": [
+        "250g fresh karonda berries, washed and halved (seeds removed if large and hard)",
+        "2-3 tablespoons mustard oil",
+        "1 teaspoon mustard seeds (rai)",
+        "1/2 teaspoon fenugreek seeds (methi dana)",
+        "1/4 teaspoon asafoetida (hing)",
+        "1 tablespoon red chili powder (adjust to taste)",
+        "1/2 teaspoon turmeric powder (haldi)",
+        "1 tablespoon salt (or to taste)",
+        "1/2 teaspoon fennel seeds (saunf), coarsely ground (optional)"
+      ],
+      "steps": [
+        "Wash the karonda berries thoroughly. Slice them in half. If the seeds are large and hard, remove them; otherwise, they can be left in.",
+        "Optional: Sun-dry the halved karondas on a clean cloth for 1-2 hours to remove excess moisture. This helps in extending the shelf life of the pickle.",
+        "Heat the mustard oil in a small pan until it just starts to smoke. Remove from heat and let it cool down until it's warm (not hot).",
+        "Once the oil is warm, add the mustard seeds and fenugreek seeds. Allow them to splutter for a few seconds.",
+        "Add the asafoetida to the oil and stir briefly.",
+        "Turn off the heat completely. Add the red chili powder, turmeric powder, salt, and optional coarsely ground fennel seeds to the warm oil. Mix all the spices well.",
+        "Add the prepared karonda berries to this spice-oil mixture. Stir thoroughly to ensure all the berries are evenly coated with the spices.",
+        "Transfer the mixture to a clean, dry glass jar with an airtight lid.",
+        "The pickle can be consumed after 1-2 days, as this allows the flavors to meld and the karondas to soften slightly. For a longer shelf life, ensure the pickle is covered with a layer of oil if possible, or store it in the refrigerator after it has matured for a few days at room temperature."
+      ]
+    }
+  ]
+}

--- a/src/lib/data/fruits/langsat.json
+++ b/src/lib/data/fruits/langsat.json
@@ -1,0 +1,149 @@
+{
+  "id": "langsat",
+  "commonName": "Langsat",
+  "scientificName": "Lansium domesticum",
+  "image": "https://upload.wikimedia.org/wikipedia/commons/thumb/1/17/Paete%2CLagunajf6182_09.JPG/800px-Paete%2CLagunajf6182_09.JPG",
+  "description": "Lansium domesticum, commonly known as langsat or lanzones, is a tropical fruit tree that bears small, ovoid to round fruits in clusters. The fruit has a thin, leathery, pale yellow to brownish skin, and translucent, juicy, sweet-tart flesh divided into segments, some of which may contain a bitter seed.",
+  "origin": "Southeast Asia (specifically Peninsular Thailand, Malaysia, Indonesia, Philippines)",
+  "localNames": [
+    "Lanzones (Philippines)",
+    "Langsat (Malaysia, Indonesia)",
+    "Longkong (Thailand - a popular cultivar)",
+    "Duku (Indonesia, Malaysia - a cultivar group)",
+    "Lòn bon (Vietnamese)"
+  ],
+  "regions": [
+    "Philippines",
+    "Indonesia",
+    "Malaysia",
+    "Thailand",
+    "Vietnam",
+    "India (Southern states)",
+    "Sri Lanka",
+    "Hawaii (USA - limited)",
+    "Costa Rica (limited)",
+    "Suriname"
+  ],
+  "seasons": [
+    "Varies by region, typically during the rainy season, often fruiting from late spring to autumn in Southeast Asia."
+  ],
+  "nutrition": {
+    "calories": "57 kcal per 100g",
+    "macronutrients": [
+      {
+        "name": "Protein",
+        "value": 0.8,
+        "unit": "g"
+      },
+      {
+        "name": "Carbohydrates",
+        "value": 14.2,
+        "unit": "g"
+      },
+      {
+        "name": "Fat",
+        "value": 0.2,
+        "unit": "g"
+      },
+      {
+        "name": "Fiber",
+        "value": 0.8,
+        "unit": "g"
+      }
+    ],
+    "vitamins": [
+      {
+        "name": "Vitamin C",
+        "value": 13,
+        "unit": "mg",
+        "rdi": "14%"
+      },
+      {
+        "name": "Vitamin A",
+        "value": 4.5,
+        "unit": "µg",
+        "rdi": "1%"
+      },
+      {
+        "name": "Thiamin (B1)",
+        "value": 0.05,
+        "unit": "mg",
+        "rdi": "4%"
+      },
+      {
+        "name": "Riboflavin (B2)",
+        "value": 0.08,
+        "unit": "mg",
+        "rdi": "6%"
+      },
+      {
+        "name": "Niacin (B3)",
+        "value": 0.5,
+        "unit": "mg",
+        "rdi": "3%"
+      }
+    ],
+    "minerals": [
+      {
+        "name": "Potassium",
+        "value": 230,
+        "unit": "mg",
+        "rdi": "5%" 
+      },
+      {
+        "name": "Phosphorus",
+        "value": 20,
+        "unit": "mg",
+        "rdi": "3%"
+      },
+      {
+        "name": "Calcium",
+        "value": 19,
+        "unit": "mg",
+        "rdi": "2%"
+      }
+    ]
+  },
+  "healthBenefits": [
+    "Provides Vitamin C, an antioxidant that supports immune function.",
+    "Contains B-vitamins like Thiamine, Riboflavin, and Niacin, which are important for energy metabolism.",
+    "Source of dietary fiber, which aids in digestion and promotes gut health."
+  ],
+  "potentialAllergies": [
+    {
+      "name": "Latex in skin (some varieties)",
+      "severity": "Mild",
+      "details": "The skin of some langsat varieties (particularly the 'Langsat' type) exudes a sticky latex when peeled, which is generally harmless but can be messy. The seeds are bitter and typically not consumed."
+    }
+  ],
+  "cultivationProcess": "Langsat trees are typically grown in humid, tropical climates and prefer well-drained, slightly acidic soil rich in organic matter. They thrive in partial shade, often cultivated in mixed agroforestry systems. Propagation can be by seeds (which have a long juvenile period, 12-25 years) or more commonly by air layering or grafting onto seedling rootstock for earlier fruiting (2-6 years) and consistent cultivar quality. Trees require consistent moisture, especially during fruit development.",
+  "growthDuration": "Seedling trees may take 12-25 years to bear fruit. Grafted or air-layered trees can start fruiting in 2-6 years, with full production varying. Fruit typically ripens about 4-5 months after flowering.",
+  "sustainabilityTips": [
+    "Supporting agroforestry systems where langsat is traditionally grown helps conserve biodiversity and soil health.",
+    "Choose locally grown langsat fruits when available to reduce the carbon footprint associated with transportation."
+  ],
+  "carbonFootprintInfo": "Langsat grown and consumed within its native Southeast Asian regions generally has a low carbon footprint. When exported, particularly fresh fruit requiring air freight due to its moderate shelf life, the carbon footprint increases significantly. Processed forms (e.g., canned in syrup) also add to the footprint through manufacturing and packaging.",
+  "staticRecipes": [
+    {
+      "name": "Langsat & Coconut Tropical Salad",
+      "description": "A refreshing and simple salad that highlights the sweet-tart flavor of langsat (lanzones), beautifully complemented by toasted coconut and fresh mint.",
+      "ingredients": [
+        "2 cups fresh langsat (lanzones), peeled",
+        "1/2 cup fresh pineapple, diced (optional)",
+        "1/4 cup toasted shredded coconut (unsweetened)",
+        "1 tablespoon fresh lime juice",
+        "1 teaspoon honey or palm sugar syrup (optional, to taste)",
+        "A few fresh mint leaves, thinly sliced (chiffonade)"
+      ],
+      "steps": [
+        "Peel the langsat fruits. This is usually done by gently squeezing or pinching the skin until it splits, then removing it. The flesh is divided into segments.",
+        "If the langsat segments contain large, green, bitter seeds, you may choose to remove them, especially from the larger segments. Smaller, undeveloped seeds are often edible or absent.",
+        "In a medium bowl, combine the peeled langsat segments and diced pineapple (if using).",
+        "In a small separate bowl, whisk together the fresh lime juice and honey or palm sugar syrup (if you are using it for added sweetness).",
+        "Pour the lime juice dressing over the fruits and toss gently to ensure they are evenly coated.",
+        "Sprinkle the toasted shredded coconut and thinly sliced fresh mint leaves over the salad.",
+        "Serve immediately for the best taste and texture, or chill for about 15-30 minutes for a more refreshing experience."
+      ]
+    }
+  ]
+}

--- a/src/lib/data/fruits/longan.json
+++ b/src/lib/data/fruits/longan.json
@@ -1,0 +1,167 @@
+{
+  "id": "longan",
+  "commonName": "Longan",
+  "scientificName": "Dimocarpus longan",
+  "image": "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c9/Dimocarpus_longan_fruits.jpg/1024px-Dimocarpus_longan_fruits.jpg",
+  "description": "Dimocarpus longan, commonly known as the longan or dragon's eye, is a tropical tree species that produces edible fruit. It belongs to the soapberry family Sapindaceae, along with lychee and rambutan. The fruit is characterized by a thin, tan-brown shell, translucent white flesh, and a single black seed, resembling an eyeball.",
+  "origin": "Southeast Asia, particularly the region between Myanmar and Southern China.",
+  "localNames": [
+    "Lóngyǎn (龙眼 - Mandarin Chinese, 'dragon eye')",
+    "Lùhng-ngáahn (龍眼 - Cantonese Chinese, 'dragon eye')",
+    "Nhãn (Vietnamese)",
+    "Mata Kucing (Malay/Indonesian, 'cat's eye')"
+  ],
+  "regions": [
+    "China (Guangdong, Fujian, Guangxi)",
+    "Thailand",
+    "Vietnam",
+    "Indonesia",
+    "Taiwan",
+    "Malaysia",
+    "India",
+    "Sri Lanka",
+    "Philippines",
+    "Australia (Queensland)",
+    "United States (Florida, Hawaii, California)"
+  ],
+  "seasons": [
+    "Late Summer to Autumn (typically July to October in the Northern Hemisphere, varying by region)"
+  ],
+  "nutrition": {
+    "calories": "60 kcal per 100g",
+    "macronutrients": [
+      {
+        "name": "Protein",
+        "value": 1.31,
+        "unit": "g"
+      },
+      {
+        "name": "Carbohydrates",
+        "value": 15.14,
+        "unit": "g"
+      },
+      {
+        "name": "Fat",
+        "value": 0.1,
+        "unit": "g"
+      },
+      {
+        "name": "Fiber",
+        "value": 1.1,
+        "unit": "g"
+      }
+    ],
+    "vitamins": [
+      {
+        "name": "Vitamin C",
+        "value": 84,
+        "unit": "mg",
+        "rdi": "93%"
+      },
+      {
+        "name": "Riboflavin (B2)",
+        "value": 0.14,
+        "unit": "mg",
+        "rdi": "11%"
+      },
+      {
+        "name": "Thiamin (B1)",
+        "value": 0.031,
+        "unit": "mg",
+        "rdi": "3%"
+      },
+      {
+        "name": "Niacin (B3)",
+        "value": 0.3,
+        "unit": "mg",
+        "rdi": "2%"
+      }
+    ],
+    "minerals": [
+      {
+        "name": "Potassium",
+        "value": 266,
+        "unit": "mg",
+        "rdi": "9%"
+      },
+      {
+        "name": "Phosphorus",
+        "value": 21,
+        "unit": "mg",
+        "rdi": "2%"
+      },
+      {
+        "name": "Magnesium",
+        "value": 10,
+        "unit": "mg",
+        "rdi": "2%"
+      },
+      {
+        "name": "Manganese",
+        "value": 0.052,
+        "unit": "mg",
+        "rdi": "2%"
+      },
+      {
+        "name": "Iron",
+        "value": 0.13,
+        "unit": "mg",
+        "rdi": "1%"
+      },
+      {
+        "name": "Calcium",
+        "value": 1,
+        "unit": "mg",
+        "rdi": "0%"
+      },
+      {
+        "name": "Zinc",
+        "value": 0.05,
+        "unit": "mg",
+        "rdi": "0%"
+      }
+    ]
+  },
+  "healthBenefits": [
+    "Excellent source of Vitamin C, which boosts the immune system and acts as an antioxidant.",
+    "Provides dietary fiber, which can aid digestion and promote gut health.",
+    "Contains minerals like potassium, important for maintaining healthy blood pressure levels."
+  ],
+  "potentialAllergies": [
+    {
+      "name": "Oral Allergy Syndrome (OAS)",
+      "severity": "Mild",
+      "details": "Rare, but individuals with allergies to other fruits in the Sapindaceae family (like lychee or rambutan) or certain pollens might experience OAS. Symptoms are usually mild and localized to the mouth and throat."
+    }
+  ],
+  "cultivationProcess": "Longan trees are subtropical and thrive in warm, humid climates with well-drained, slightly acidic sandy soils. They are typically propagated by air layering (marcotting) for commercial cultivation, as seed propagation takes longer to bear fruit and may not retain parent characteristics. Trees require regular watering, especially during dry periods and fruit development, and benefit from balanced fertilization. Pruning is done to shape the tree, improve air circulation, and encourage fruiting.",
+  "growthDuration": "Grafted or air-layered trees typically begin to bear fruit within 2-4 years, with significant yields achieved by 4-5 years. Trees grown from seed may take 6-8 years or longer to start fruiting. Fruit matures in summer to early autumn.",
+  "sustainabilityTips": [
+    "Choose locally grown longans when in season to reduce carbon emissions from transportation.",
+    "Compost fruit peels and seeds to reduce waste and enrich soil."
+  ],
+  "carbonFootprintInfo": "The carbon footprint of longans is lowest when sourced locally and consumed in season. Long-distance transportation, especially by air freight for fresh fruit, significantly increases its environmental impact. Dried longans have a longer shelf life, potentially reducing waste but involving energy for drying.",
+  "staticRecipes": [
+    {
+      "name": "Sweet Longan and Lotus Seed Dessert Soup (Tong Sui)",
+      "description": "A popular and refreshing Chinese dessert soup (tong sui) featuring the sweet flavors of longan and the soft texture of lotus seeds. Often enjoyed warm or chilled.",
+      "ingredients": [
+        "1/2 cup dried longan pulp",
+        "1/4 cup dried lotus seeds (skinless and cored)",
+        "4-6 cups water",
+        "Rock sugar to taste (e.g., 1/4 to 1/2 cup, or use granulated sugar)"
+      ],
+      "steps": [
+        "Rinse the dried longan pulp and dried lotus seeds thoroughly under cold water.",
+        "If your lotus seeds are not pre-cored, slice each seed in half and remove the bitter green germ (core) from the center.",
+        "Soak the dried lotus seeds in warm water for at least 1 hour, or until they are somewhat softened. Some prefer to soak them for longer (2-3 hours or overnight) for a softer texture.",
+        "In a medium-sized pot, combine the rinsed longan pulp, soaked and cored lotus seeds, and the 4-6 cups of water.",
+        "Bring the mixture to a boil over high heat.",
+        "Once boiling, reduce the heat to low, cover the pot, and let it simmer for 30-45 minutes, or until the lotus seeds are tender and can be easily pierced with a fork.",
+        "Add rock sugar (or granulated sugar) to the pot according to your preference for sweetness. Start with a smaller amount, stir until it dissolves completely, then taste and add more if needed.",
+        "Continue to simmer for another 5-10 minutes to allow the sugar to fully incorporate and the flavors to meld.",
+        "Serve the dessert soup warm in bowls. It can also be chilled in the refrigerator and served cold, which is particularly refreshing in warmer weather."
+      ]
+    }
+  ]
+}

--- a/src/lib/data/fruits/loquat.json
+++ b/src/lib/data/fruits/loquat.json
@@ -1,0 +1,164 @@
+{
+  "id": "loquat",
+  "commonName": "Loquat",
+  "scientificName": "Eriobotrya japonica",
+  "image": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/d9/Loquat-0.jpg/800px-Loquat-0.jpg",
+  "description": "The loquat (Eriobotrya japonica) is a large evergreen shrub or small tree known for its clusters of small, oval or pear-shaped orange-yellow fruits. The fruit has a tangy, sweet to subacid flavor, with a succulent flesh that can be white, yellow, or orange.",
+  "origin": "Native to the cooler hill regions of south-central China.",
+  "localNames": [
+    "Pípá (枇杷 - Chinese)",
+    "Biwa (ビワ - Japanese)",
+    "Níspero Japonés (Spanish)",
+    "Nèfle du Japon (French)",
+    "Japanische Mispel (German)",
+    "Japanese Plum (English)"
+  ],
+  "regions": [
+    "China (major producer)",
+    "Japan",
+    "Spain (major producer)",
+    "Turkey",
+    "Pakistan",
+    "India",
+    "Mediterranean countries (Italy, Greece, Israel, Lebanon)",
+    "United States (California, Florida, Hawaii)",
+    "Brazil",
+    "Chile",
+    "Australia"
+  ],
+  "seasons": [
+    "Late winter to early summer (typically flowering in autumn/winter and fruiting in spring/early summer, depending on the climate)"
+  ],
+  "nutrition": {
+    "calories": "47 kcal per 100g",
+    "macronutrients": [
+      {
+        "name": "Protein",
+        "value": 0.43,
+        "unit": "g"
+      },
+      {
+        "name": "Carbohydrates",
+        "value": 12.14,
+        "unit": "g"
+      },
+      {
+        "name": "Fat",
+        "value": 0.2,
+        "unit": "g"
+      },
+      {
+        "name": "Fiber",
+        "value": 1.7,
+        "unit": "g"
+      }
+    ],
+    "vitamins": [
+      {
+        "name": "Vitamin A",
+        "value": 76,
+        "unit": "µg",
+        "rdi": "8%"
+      },
+      {
+        "name": "Vitamin B6",
+        "value": 0.1,
+        "unit": "mg",
+        "rdi": "6%"
+      },
+      {
+        "name": "Vitamin C",
+        "value": 1,
+        "unit": "mg",
+        "rdi": "1%"
+      },
+      {
+        "name": "Folate (B9)",
+        "value": 14,
+        "unit": "µg",
+        "rdi": "4%"
+      }
+    ],
+    "minerals": [
+      {
+        "name": "Potassium",
+        "value": 266,
+        "unit": "mg",
+        "rdi": "6%" 
+      },
+      {
+        "name": "Manganese",
+        "value": 0.148,
+        "unit": "mg",
+        "rdi": "7%" 
+      },
+      {
+        "name": "Iron",
+        "value": 0.28,
+        "unit": "mg",
+        "rdi": "2%"
+      },
+      {
+        "name": "Magnesium",
+        "value": 13,
+        "unit": "mg",
+        "rdi": "3%"
+      },
+      {
+        "name": "Phosphorus",
+        "value": 27,
+        "unit": "mg",
+        "rdi": "2%"
+      },
+      {
+        "name": "Calcium",
+        "value": 16,
+        "unit": "mg",
+        "rdi": "1%"
+      }
+    ]
+  },
+  "healthBenefits": [
+    "Good source of Vitamin A, which is essential for good vision, immune function, and skin health.",
+    "Contains dietary fiber, aiding digestion, promoting satiety, and helping to regulate blood sugar levels.",
+    "Provides potassium, an important mineral for maintaining healthy blood pressure and heart function."
+  ],
+  "potentialAllergies": [
+    {
+      "name": "Cyanogenic glycosides in seeds",
+      "severity": "Low to Moderate (if seeds ingested in quantity)",
+      "details": "Loquat seeds (pips) and young leaves contain small amounts of cyanogenic glycosides like amygdalin, which can release cyanide if chewed and ingested in significant quantities. The bitter taste usually prevents consumption of enough seeds to cause harm. The fruit flesh is safe."
+    }
+  ],
+  "cultivationProcess": "Loquat trees are evergreen and adapt to subtropical to mild temperate climates. They are unique in that they flower in autumn or early winter and produce fruit in early spring to early summer. Loquats prefer well-drained soil and full sun for best fruit production. Propagation is often by grafting or budding to maintain cultivar characteristics, though they can be grown from seed. Pruning helps to manage tree size and shape, and to improve fruit quality by thinning.",
+  "growthDuration": "Grafted loquat trees can begin to bear fruit within 2-3 years, while seedling trees may take 5-8 years. Trees can grow 5-10 meters tall but are often kept smaller in cultivation. The fruit typically ripens about 90 days after full flower bloom.",
+  "sustainabilityTips": [
+    "Loquats are relatively drought-tolerant once established, making them a good choice for water-wise gardens in suitable climates.",
+    "Support local growers or grow your own, as loquats have a short shelf life and are best consumed fresh, reducing the need for long-distance transport and preservation."
+  ],
+  "carbonFootprintInfo": "Loquats grown and consumed locally, especially from home gardens or small orchards with minimal inputs, have a low carbon footprint. Fruit imported from distant regions, particularly if air-freighted due to its perishability, will have a considerably higher environmental impact.",
+  "staticRecipes": [
+    {
+      "name": "Simple Loquat Jam",
+      "description": "A delightful homemade jam that captures the unique sweet-tart flavor of fresh loquats. It's excellent on toast, scones, or as a glaze.",
+      "ingredients": [
+        "1 kg ripe loquats, washed, halved, and seeds removed",
+        "500g granulated sugar (adjust based on sweetness of fruit and preference)",
+        "Juice of 1 large lemon (about 2-3 tablespoons)",
+        "1/4 cup water (optional, use if loquats are not very juicy)"
+      ],
+      "steps": [
+        "Prepare the loquats: After washing, halve the loquats and remove all seeds and the tough inner membrane. You can choose to peel the skin or leave it on (skin contains pectin which aids setting). Roughly chop if desired.",
+        "Combine the prepared loquats, granulated sugar, lemon juice, and optional water in a large, heavy-bottomed stainless steel or enamel saucepan.",
+        "Stir the mixture well and let it sit for about 30-60 minutes. This process, called maceration, helps the sugar to draw juice out of the fruit.",
+        "Place the saucepan over medium-low heat. Cook, stirring gently and frequently, until the sugar has completely dissolved. Do not allow the mixture to boil at this stage.",
+        "Once the sugar is dissolved, increase the heat to medium-high and bring the mixture to a rolling boil (a boil that continues bubbling even when you stir it).",
+        "Continue to boil rapidly, stirring often to prevent the jam from sticking to the bottom of the pan. Cook for approximately 20-30 minutes, or until the jam reaches its setting point.",
+        "To test for setting point: Remove the saucepan from the heat. Place a small spoonful of jam onto a chilled saucer (kept in the freezer). Allow it to cool for about 30 seconds, then gently push the jam with your fingertip. If the surface wrinkles, the jam is set. Alternatively, use a jam thermometer; the setting point is 105°C (221°F).",
+        "Once the setting point is reached, remove the saucepan from the heat. Skim off any foam (scum) from the surface using a slotted spoon, if desired.",
+        "Carefully ladle the hot jam into warm, sterilized glass jars, leaving about 1/4 inch (0.5 cm) of headspace at the top.",
+        "Wipe the jar rims clean, place the lids on, and tighten the screw bands. Allow the jars to cool completely undisturbed. As the jam cools, you should hear the lids pop, indicating a good seal. The jam will thicken further as it cools."
+      ]
+    }
+  ]
+}

--- a/src/lib/data/fruits/mangosteen.json
+++ b/src/lib/data/fruits/mangosteen.json
@@ -1,0 +1,186 @@
+{
+  "id": "mangosteen",
+  "commonName": "Mangosteen",
+  "scientificName": "Garcinia mangostana",
+  "image": "https://upload.wikimedia.org/wikipedia/commons/a/a2/MangosteenFruit.jpg",
+  "description": "Mangosteen (Garcinia mangostana), often hailed as the 'Queen of Fruits', is a tropical evergreen tree that yields an exquisite fruit with a deep purple rind and sweet, tangy, juicy white flesh. The fruit is renowned for its unique flavor and delicate texture.",
+  "origin": "Island Southeast Asia (likely the Malay Peninsula, Borneo, or Sumatra)",
+  "localNames": [
+    "Manggis (Malay, Indonesian)",
+    "Măng cụt (Vietnamese)",
+    "Mangkut (มังคุด - Thai)",
+    "Sāntol (Tagalog - sometimes confused, but mangosteen is also directly used)"
+  ],
+  "regions": [
+    "Thailand",
+    "Indonesia",
+    "Malaysia",
+    "Philippines",
+    "Vietnam",
+    "Myanmar",
+    "Sri Lanka",
+    "India (Kerala, Tamil Nadu)",
+    "Colombia",
+    "Puerto Rico",
+    "Australia (Queensland - limited)",
+    "United States (Florida, Hawaii - limited)"
+  ],
+  "seasons": [
+    "Varies by region, generally during the rainy season. Main harvest often May to October in Southeast Asia."
+  ],
+  "nutrition": {
+    "calories": "73 kcal per 100g",
+    "macronutrients": [
+      {
+        "name": "Protein",
+        "value": 0.41,
+        "unit": "g"
+      },
+      {
+        "name": "Carbohydrates",
+        "value": 17.91,
+        "unit": "g"
+      },
+      {
+        "name": "Fat",
+        "value": 0.58,
+        "unit": "g"
+      },
+      {
+        "name": "Fiber",
+        "value": 1.8,
+        "unit": "g"
+      }
+    ],
+    "vitamins": [
+      {
+        "name": "Vitamin C",
+        "value": 2.9,
+        "unit": "mg",
+        "rdi": "3%"
+      },
+      {
+        "name": "Folate (B9)",
+        "value": 31,
+        "unit": "µg",
+        "rdi": "8%"
+      },
+      {
+        "name": "Thiamin (B1)",
+        "value": 0.054,
+        "unit": "mg",
+        "rdi": "5%"
+      },
+      {
+        "name": "Riboflavin (B2)",
+        "value": 0.054,
+        "unit": "mg",
+        "rdi": "4%"
+      },
+      {
+        "name": "Niacin (B3)",
+        "value": 0.286,
+        "unit": "mg",
+        "rdi": "2%"
+      },
+      {
+        "name": "Pantothenic acid (B5)",
+        "value": 0.032,
+        "unit": "mg",
+        "rdi": "1%"
+      },
+      {
+        "name": "Vitamin B6",
+        "value": 0.018,
+        "unit": "mg",
+        "rdi": "1%"
+      }
+    ],
+    "minerals": [
+      {
+        "name": "Manganese",
+        "value": 0.102,
+        "unit": "mg",
+        "rdi": "4%"
+      },
+      {
+        "name": "Magnesium",
+        "value": 13,
+        "unit": "mg",
+        "rdi": "3%"
+      },
+      {
+        "name": "Potassium",
+        "value": 48,
+        "unit": "mg",
+        "rdi": "1%" 
+      },
+      {
+        "name": "Iron",
+        "value": 0.3,
+        "unit": "mg",
+        "rdi": "2%"
+      },
+      {
+        "name": "Calcium",
+        "value": 12,
+        "unit": "mg",
+        "rdi": "1%"
+      },
+      {
+        "name": "Phosphorus",
+        "value": 8,
+        "unit": "mg",
+        "rdi": "1%"
+      },
+      {
+        "name": "Zinc",
+        "value": 0.21,
+        "unit": "mg",
+        "rdi": "2%"
+      }
+    ]
+  },
+  "healthBenefits": [
+    "The fruit's pericarp (rind) is rich in polyphenols, particularly xanthones like mangostin, which possess antioxidant and anti-inflammatory properties (though the rind is bitter and not typically consumed fresh).",
+    "The edible flesh provides dietary fiber, which supports digestive health.",
+    "Contains various vitamins and minerals, contributing to overall nutrition, although generally in modest amounts in the flesh."
+  ],
+  "potentialAllergies": [
+    {
+      "name": "Latex-fruit syndrome (potential)",
+      "severity": "Mild to Moderate",
+      "details": "Individuals with latex allergies may rarely experience cross-reactivity with mangosteen. Symptoms could include itching, hives, or other allergic reactions. Otherwise, mangosteen is generally well-tolerated."
+    }
+  ],
+  "cultivationProcess": "Mangosteen is an ultra-tropical tree requiring high humidity, consistent rainfall, and warm temperatures (ideally 25–35°C), with no tolerance for temperatures below 4°C. It prefers deep, well-drained, slightly acidic soil rich in organic matter. Propagation is primarily by seeds, which are apomictic (genetically identical to the mother tree), as vegetative propagation is difficult. Trees are slow-growing, especially in the early years, and require partial shade when young. Full sun is tolerated by mature trees.",
+  "growthDuration": "Mangosteen trees are notoriously slow-growing. They typically take 6 to 12 years from seedling to first fruit production, though some may bear earlier under optimal conditions. The fruit itself takes about 5-6 months to mature after flowering.",
+  "sustainabilityTips": [
+    "Due to its specific tropical climate needs, mangosteens are often imported. Opt for fruit shipped by sea rather than air-freighted to reduce carbon emissions.",
+    "Support fair-trade certified mangosteens if available, as they are often grown by smallholders in developing countries."
+  ],
+  "carbonFootprintInfo": "Fresh mangosteens imported to non-tropical countries generally have a high carbon footprint due to the necessity of air freight for their short shelf life and delicate nature. Locally consumed mangosteens in their native regions have a much lower impact. Processed forms (canned, frozen) may vary depending on processing and transportation methods.",
+  "staticRecipes": [
+    {
+      "name": "Fresh Mangosteen Salad",
+      "description": "A simple and refreshing salad that highlights the unique sweet-tart flavor of fresh mangosteens, often paired with other tropical fruits.",
+      "ingredients": [
+        "8-10 fresh mangosteens",
+        "1 cup diced ripe mango",
+        "1 cup diced fresh pineapple",
+        "1 tablespoon fresh lime juice (optional)",
+        "1 teaspoon honey or agave nectar (optional, if fruits are not very sweet)",
+        "A few fresh mint leaves, chiffonade (optional, for garnish)"
+      ],
+      "steps": [
+        "Prepare the mangosteens: Using a sharp knife, carefully score the rind around the middle of each mangosteen, being cautious not to cut through to the flesh.",
+        "Gently twist the scored rind to separate the two halves. Remove the top half of the rind.",
+        "Carefully scoop out the white, fleshy segments from the rind. The larger segments may contain a seed; these can be removed if desired, though smaller seeds are often soft enough to be eaten.",
+        "In a medium bowl, combine the fresh mangosteen segments, diced mango, and diced pineapple.",
+        "If using, drizzle the lime juice and honey (or agave nectar) over the fruit mixture. Toss gently to combine.",
+        "Serve immediately, or chill for about 15-30 minutes to enhance the refreshing quality.",
+        "Garnish with fresh mint leaves before serving, if desired."
+      ]
+    }
+  ]
+}

--- a/src/lib/data/fruits/noni-fruit.json
+++ b/src/lib/data/fruits/noni-fruit.json
@@ -1,0 +1,113 @@
+{
+  "id": "noni-fruit",
+  "commonName": "Noni Fruit",
+  "scientificName": "Morinda citrifolia",
+  "image": "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a2/Noni_fruit_%28Morinda_citrifolia%29.jpg/800px-Noni_fruit_%28Morinda_citrifolia%29.jpg",
+  "description": "Noni (Morinda citrifolia) is a tropical fruit known for its distinctive bumpy appearance, strong pungent odor (often likened to rotten cheese) when ripe, and its historical use as a traditional medicine and famine food in various cultures. The fruit transitions from green to yellow-white as it matures.",
+  "origin": "Southeast Asia and Australasia",
+  "localNames": [
+    "Indian Mulberry (English)",
+    "Beach Mulberry (English)",
+    "Vomit Fruit (English)",
+    "Rotten Cheese Fruit (English)",
+    "Noni (Hawaiian, and widely used)",
+    "Nonu (Samoan, Tongan)",
+    "Nono (Tahitian)",
+    "Mengkudu (Malay, Indonesian)"
+  ],
+  "regions": [
+    "Pacific Islands (Hawaii, Tahiti, Fiji, Samoa, Cook Islands)",
+    "Southeast Asia (Indonesia, Malaysia, Philippines, Vietnam)",
+    "Australasia (Australia - Queensland)",
+    "India",
+    "Caribbean",
+    "South and Central America (limited cultivation)"
+  ],
+  "seasons": [
+    "Year-round in tropical climates; trees can simultaneously bear flowers, immature fruit, and mature fruit."
+  ],
+  "nutrition": {
+    "calories": "47 kcal per 100g",
+    "macronutrients": [
+      {
+        "name": "Protein",
+        "value": 0.43,
+        "unit": "g"
+      },
+      {
+        "name": "Carbohydrates",
+        "value": 11.3,
+        "unit": "g"
+      },
+      {
+        "name": "Fat",
+        "value": 0.1,
+        "unit": "g"
+      },
+      {
+        "name": "Fiber",
+        "value": 0.2,
+        "unit": "g"
+      }
+    ],
+    "vitamins": [
+      {
+        "name": "Vitamin C",
+        "value": 33,
+        "unit": "mg",
+        "rdi": "37%"
+      }
+    ],
+    "minerals": [
+      {
+        "name": "Potassium",
+        "value": 140,
+        "unit": "mg",
+        "rdi": "3%"
+      }
+    ]
+  },
+  "healthBenefits": [
+    "Traditionally used in Polynesian and other indigenous cultures for a wide range of ailments and as a general health tonic.",
+    "Source of Vitamin C, which contributes to immune function and antioxidant protection.",
+    "Contains various phytochemicals, such as flavonoids and lignans, which are being researched for their antioxidant and other potential health effects (though clinical evidence for many traditional claims is limited)."
+  ],
+  "potentialAllergies": [
+    {
+      "name": "High Potassium Content",
+      "severity": "Moderate to High",
+      "details": "Noni products, especially juice, can be high in potassium. Individuals with kidney disease or those on potassium-restricted diets should consult a healthcare provider before consuming noni."
+    },
+    {
+      "name": "Liver Toxicity Reports",
+      "severity": "Moderate to High",
+      "details": "There have been isolated case reports linking consumption of noni products (particularly concentrated supplements) to liver damage in susceptible individuals. It is advisable to use with caution and consult a healthcare provider, especially if there are pre-existing liver conditions."
+    }
+  ],
+  "cultivationProcess": "Morinda citrifolia is a hardy tree or shrub that grows well in a variety of environments, including shady forests and open sandy or rocky shores. It tolerates saline soils, drought conditions, and secondary soils. Propagation can be done by seeds, cuttings, or air layering. The plant is resilient and often requires minimal care once established in a suitable tropical or subtropical climate.",
+  "growthDuration": "Noni trees typically mature and begin fruiting within 12-18 months after planting. They can produce fruit year-round, with flowers, immature, and mature fruit often present on the tree simultaneously.",
+  "sustainabilityTips": [
+    "Noni is a resilient plant that can be grown with minimal inputs in its native regions, often contributing to local traditional ecosystems.",
+    "When choosing noni products, consider those sourced from sustainable, organic farming practices that support local communities."
+  ],
+  "carbonFootprintInfo": "Fresh noni fruit consumed locally in its growing regions has a relatively low carbon footprint. However, processed noni products (juices, powders, supplements) that are packaged and transported internationally will have a higher carbon footprint due to manufacturing, packaging, and long-distance shipping.",
+  "staticRecipes": [
+    {
+      "name": "Traditional Fermented Noni Juice",
+      "description": "A traditional method of preparing noni juice, involving natural fermentation. This process is believed to mellow the fruit's strong flavor and potentially enhance the bioavailability of its compounds. It is often consumed in small amounts for wellness purposes.",
+      "ingredients": [
+        "Ripe noni fruits (soft, translucent white/yellow)",
+        "Clean glass jar with a non-airtight lid or cheesecloth cover"
+      ],
+      "steps": [
+        "Wash ripe noni fruits thoroughly with clean water. Ensure they are free of dirt or debris.",
+        "Place the whole, ripe noni fruits into the clean glass jar. Do not add any water, sugar, or other ingredients.",
+        "Cover the jar. If using a lid, do not seal it completely airtight to allow fermentation gases to escape. Alternatively, cover the mouth of the jar with a piece of cheesecloth secured with a rubber band or string.",
+        "Place the jar in a warm, dark place (like a cupboard) or, as some traditions prefer, in direct sunlight. The fermentation time can vary widely, from a few days to several weeks (e.g., 3 days to 8 weeks), depending on ambient temperature and desired potency/flavor.",
+        "The fruit will gradually break down and release its juice. Natural fermentation will occur, evidenced by bubbling or changes in aroma.",
+        "Once the desired fermentation period is complete, strain the juice from the fruit pulp using a clean cheesecloth or a fine-mesh sieve into another clean jar or bottle.",
+        "Store the strained noni juice in the refrigerator. It is typically consumed in small quantities, such as 1-2 tablespoons (15-30ml) per day, often diluted with water or other juices due to its strong taste."
+      ]
+    }
+  ]
+}

--- a/src/lib/data/fruits/persimmon.json
+++ b/src/lib/data/fruits/persimmon.json
@@ -1,0 +1,192 @@
+{
+  "id": "persimmon",
+  "commonName": "Persimmon",
+  "scientificName": "Diospyros kaki",
+  "image": "https://upload.wikimedia.org/wikipedia/commons/thumb/a/ae/Kaki_20041002.jpg/800px-Kaki_20041002.jpg",
+  "description": "The Oriental persimmon (Diospyros kaki) is a deciduous tree that produces sweet, edible fruit, typically orange to reddish-orange. Fruits are broadly classified as astringent (e.g., 'Hachiya', which must be fully soft before eating to lose tartness) or non-astringent (e.g., 'Fuyu', which can be eaten firm like an apple). The flesh ranges from soft and jelly-like to crisp, depending on variety and ripeness.",
+  "origin": "Native to China, with cultivation dating back over 2000 years.",
+  "localNames": [
+    "Kaki (柿 - Japanese)",
+    "Shì (柿 - Chinese)",
+    "Gam (감 - Korean)",
+    "Sharon Fruit (Israel - specific 'Triumph' cultivar)",
+    "Caqui (Spanish, Portuguese)"
+  ],
+  "regions": [
+    "China (world's largest producer)",
+    "South Korea",
+    "Japan",
+    "Brazil",
+    "Azerbaijan",
+    "Spain (Valencian region)",
+    "Italy",
+    "Israel",
+    "United States (California, Florida)",
+    "Australia",
+    "New Zealand"
+  ],
+  "seasons": [
+    "Autumn to early Winter (typically September to December in the Northern Hemisphere)"
+  ],
+  "nutrition": {
+    "calories": "70 kcal per 100g",
+    "macronutrients": [
+      {
+        "name": "Protein",
+        "value": 0.58,
+        "unit": "g"
+      },
+      {
+        "name": "Carbohydrates",
+        "value": 18.59,
+        "unit": "g"
+      },
+      {
+        "name": "Fat",
+        "value": 0.19,
+        "unit": "g"
+      },
+      {
+        "name": "Fiber",
+        "value": 3.6,
+        "unit": "g"
+      }
+    ],
+    "vitamins": [
+      {
+        "name": "Vitamin A",
+        "value": 81,
+        "unit": "µg",
+        "rdi": "9%"
+      },
+      {
+        "name": "Vitamin C",
+        "value": 7.5,
+        "unit": "mg",
+        "rdi": "8%"
+      },
+      {
+        "name": "Vitamin K",
+        "value": 2.6,
+        "unit": "µg",
+        "rdi": "2%"
+      },
+      {
+        "name": "Vitamin B6",
+        "value": 0.1,
+        "unit": "mg",
+        "rdi": "6%"
+      },
+      {
+        "name": "Folate (B9)",
+        "value": 8,
+        "unit": "µg",
+        "rdi": "2%"
+      },
+      {
+        "name": "Niacin (B3)",
+        "value": 0.1,
+        "unit": "mg",
+        "rdi": "1%"
+      },
+      {
+        "name": "Thiamin (B1)",
+        "value": 0.03,
+        "unit": "mg",
+        "rdi": "3%"
+      },
+      {
+        "name": "Riboflavin (B2)",
+        "value": 0.02,
+        "unit": "mg",
+        "rdi": "2%"
+      }
+    ],
+    "minerals": [
+      {
+        "name": "Manganese",
+        "value": 0.355,
+        "unit": "mg",
+        "rdi": "15%"
+      },
+      {
+        "name": "Potassium",
+        "value": 161,
+        "unit": "mg",
+        "rdi": "3%"
+      },
+      {
+        "name": "Copper",
+        "value": 0.04,
+        "unit": "mg",
+        "rdi": "4%"
+      },
+      {
+        "name": "Phosphorus",
+        "value": 17,
+        "unit": "mg",
+        "rdi": "2%"
+      },
+      {
+        "name": "Magnesium",
+        "value": 9,
+        "unit": "mg",
+        "rdi": "2%"
+      },
+      {
+        "name": "Calcium",
+        "value": 8,
+        "unit": "mg",
+        "rdi": "1%"
+      },
+      {
+        "name": "Iron",
+        "value": 0.15,
+        "unit": "mg",
+        "rdi": "1%"
+      }
+    ]
+  },
+  "healthBenefits": [
+    "Rich in Vitamin A (from carotenoids like beta-cryptoxanthin and beta-carotene), which is crucial for good vision, immune function, and skin health.",
+    "Good source of dietary fiber, aiding digestion, promoting regularity, and helping to manage blood sugar levels.",
+    "Contains various antioxidants, including Vitamin C and manganese, which help protect the body against oxidative stress."
+  ],
+  "potentialAllergies": [
+    {
+      "name": "Tannin Astringency (unripe fruit)",
+      "severity": "Mild to Moderate (mouthfeel)",
+      "details": "Astringent varieties (e.g., Hachiya) are high in tannins when unripe or firm, causing a dry, puckering sensation in the mouth. These should be eaten only when fully soft and ripe. Non-astringent varieties (e.g., Fuyu) lack this issue. Rarely, consumption of large quantities of unripe astringent persimmons has been linked to bezoar formation."
+    }
+  ],
+  "cultivationProcess": "Persimmon trees (Diospyros kaki) are deciduous and can grow up to 10 meters tall. They prefer temperate and subtropical climates with distinct seasons. Most varieties require a period of winter chill. Trees are often dioecious (separate male and female trees), but many commercial cultivars are parthenocarpic (set fruit without pollination) or self-fruitful. They thrive in deep, well-drained loamy soil and require full sun for optimal fruit production. Pruning is done to maintain tree structure and fruit quality.",
+  "growthDuration": "Persimmon trees typically begin to bear fruit 3 to 6 years after planting. The fruit ripens in the autumn, often after the leaves have started to change color or fall.",
+  "sustainabilityTips": [
+    "Choose locally grown persimmons during their autumn season to reduce the carbon footprint from long-distance transportation and storage.",
+    "Persimmon trees can be relatively low-maintenance in suitable climates, sometimes requiring less water than other fruit trees once established."
+  ],
+  "carbonFootprintInfo": "Locally grown persimmons consumed in season generally have a moderate carbon footprint. However, persimmons imported from distant countries, especially if requiring refrigeration and significant transport logistics, will have a higher environmental impact.",
+  "staticRecipes": [
+    {
+      "name": "Simple Persimmon & Yogurt Parfait",
+      "description": "A quick and healthy breakfast or dessert layering sweet, ripe persimmons with creamy yogurt and crunchy granola. Best made with non-astringent Fuyu persimmons.",
+      "ingredients": [
+        "2 ripe Fuyu persimmons (or other non-astringent type), peeled (optional) and diced",
+        "1 cup Greek yogurt (or plain yogurt of choice)",
+        "1/2 cup granola",
+        "1 tablespoon honey or maple syrup (optional)",
+        "Pinch of ground cinnamon or nutmeg (optional)"
+      ],
+      "steps": [
+        "Prepare the persimmons: Wash the persimmons thoroughly. Peel if desired (the skin of Fuyu persimmons is edible), then dice into bite-sized pieces. Ensure the persimmons are ripe and sweet.",
+        "Choose two serving glasses or small bowls.",
+        "Create the first layer by placing half of the diced persimmons at the bottom of each glass.",
+        "Add a layer of Greek yogurt (about 1/2 cup per glass) over the persimmons.",
+        "Sprinkle a layer of granola (about 1/4 cup per glass) over the yogurt.",
+        "If using, drizzle the top layer of granola with honey or maple syrup.",
+        "Add a final pinch of cinnamon or nutmeg on top if desired.",
+        "Serve immediately to enjoy the contrast of crunchy granola and soft fruit. Alternatively, it can be chilled for a short period, but the granola may soften over time."
+      ]
+    }
+  ]
+}

--- a/src/lib/data/fruits/rambutan.json
+++ b/src/lib/data/fruits/rambutan.json
@@ -1,0 +1,180 @@
+{
+  "id": "rambutan",
+  "commonName": "Rambutan",
+  "scientificName": "Nephelium lappaceum",
+  "image": "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c3/Rambutan_fruits.jpg/1024px-Rambutan_fruits.jpg",
+  "description": "Rambutan (Nephelium lappaceum) is a tropical fruit native to Southeast Asia, known for its distinctive appearance with a leathery, reddish (or sometimes yellow) skin covered in fleshy, pliable spines or 'hairs'. The translucent, white or pale pink flesh is sweet, juicy, and mildly acidic.",
+  "origin": "Southeast Asia (likely the Malay Archipelago - Indonesia, Malaysia)",
+  "localNames": [
+    "Rambut (Malay/Indonesian, meaning 'hair')",
+    "Chôm chôm (Vietnamese, meaning 'messy hair')",
+    "Ngoh (เงาะ - Thai)",
+    "Hóngmáodān (红毛丹 - Chinese, 'red-haired pellet')"
+  ],
+  "regions": [
+    "Indonesia",
+    "Malaysia",
+    "Thailand",
+    "Vietnam",
+    "Philippines",
+    "Sri Lanka",
+    "India",
+    "Australia (Queensland)",
+    "Central America (Costa Rica, Honduras, Panama)",
+    "South America (Ecuador, Colombia, Suriname)",
+    "Africa (Zanzibar, Pemba)",
+    "Caribbean islands (Puerto Rico, Trinidad, Cuba)"
+  ],
+  "seasons": [
+    "Varies by region; typically late fall to early winter, with a shorter secondary season in late spring to early summer in some areas. Main harvest often August-September in Central America."
+  ],
+  "nutrition": {
+    "calories": "82 kcal per 100g",
+    "macronutrients": [
+      {
+        "name": "Protein",
+        "value": 0.65,
+        "unit": "g"
+      },
+      {
+        "name": "Carbohydrates",
+        "value": 20.87,
+        "unit": "g"
+      },
+      {
+        "name": "Fat",
+        "value": 0.21,
+        "unit": "g"
+      },
+      {
+        "name": "Fiber",
+        "value": 0.9,
+        "unit": "g"
+      }
+    ],
+    "vitamins": [
+      {
+        "name": "Vitamin C",
+        "value": 4.9,
+        "unit": "mg",
+        "rdi": "5%"
+      },
+      {
+        "name": "Niacin (B3)",
+        "value": 1.352,
+        "unit": "mg",
+        "rdi": "8%"
+      },
+      {
+        "name": "Folate (B9)",
+        "value": 8,
+        "unit": "µg",
+        "rdi": "2%"
+      },
+      {
+        "name": "Riboflavin (B2)",
+        "value": 0.022,
+        "unit": "mg",
+        "rdi": "2%"
+      },
+      {
+        "name": "Thiamin (B1)",
+        "value": 0.013,
+        "unit": "mg",
+        "rdi": "1%"
+      },
+      {
+        "name": "Vitamin B6",
+        "value": 0.02,
+        "unit": "mg",
+        "rdi": "1%"
+      }
+    ],
+    "minerals": [
+      {
+        "name": "Manganese",
+        "value": 0.343,
+        "unit": "mg",
+        "rdi": "15%"
+      },
+      {
+        "name": "Potassium",
+        "value": 42,
+        "unit": "mg",
+        "rdi": "1%"
+      },
+      {
+        "name": "Calcium",
+        "value": 22,
+        "unit": "mg",
+        "rdi": "2%"
+      },
+      {
+        "name": "Iron",
+        "value": 0.35,
+        "unit": "mg",
+        "rdi": "2%"
+      },
+      {
+        "name": "Magnesium",
+        "value": 7,
+        "unit": "mg",
+        "rdi": "2%"
+      },
+      {
+        "name": "Phosphorus",
+        "value": 9,
+        "unit": "mg",
+        "rdi": "1%"
+      },
+      {
+        "name": "Zinc",
+        "value": 0.08,
+        "unit": "mg",
+        "rdi": "1%"
+      }
+    ]
+  },
+  "healthBenefits": [
+    "Provides a good source of manganese, an essential mineral for enzyme function, metabolism, and antioxidant defense.",
+    "Contains Vitamin C, which supports the immune system and acts as an antioxidant.",
+    "Offers dietary fiber, which can aid in digestion and promote gut health."
+  ],
+  "potentialAllergies": [
+    {
+      "name": "Cross-reactivity (rare)",
+      "severity": "Mild",
+      "details": "Generally well-tolerated. Rare cross-reactivity may occur in individuals with allergies to other fruits in the Sapindaceae family (e.g., lychee, longan) or birch pollen (Oral Allergy Syndrome)."
+    }
+  ],
+  "cultivationProcess": "Rambutan trees thrive in warm, humid tropical climates (22–30°C) and prefer deep, well-drained clay loam or sandy loam soil rich in organic matter. Commercial propagation is mainly through grafting, air-layering, or budding to ensure true-to-type fruit. Trees require consistent moisture, especially during fruit development, and benefit from regular fertilization. Pollination is primarily carried out by insects, such as bees and flies.",
+  "growthDuration": "Grafted or budded rambutan trees typically start bearing fruit within 2-3 years, reaching optimal production in 8-10 years. Trees grown from seed may take 5-6 years to begin fruiting. The fruit matures approximately 15-18 weeks after the flowers bloom.",
+  "sustainabilityTips": [
+    "Opt for locally grown rambutans when available to minimize the carbon footprint associated with long-distance transportation.",
+    "Compost the inedible spiny peel and seed to reduce organic waste and create nutrient-rich soil amendment."
+  ],
+  "carbonFootprintInfo": "Rambutans cultivated and consumed locally in tropical regions have a relatively low carbon footprint. However, when imported to non-tropical countries, they often require air freight due to their short shelf life, significantly increasing their environmental impact. Choosing sea-freighted or processed (canned, dried) options can be more sustainable if fresh local fruit isn't available.",
+  "staticRecipes": [
+    {
+      "name": "Refreshing Rambutan & Pineapple Cooler",
+      "description": "A simple and thirst-quenching tropical drink that beautifully combines the sweet, unique flavor of rambutan with the tartness of pineapple.",
+      "ingredients": [
+        "10-12 fresh rambutans",
+        "1 cup fresh pineapple chunks",
+        "1 cup cold water or coconut water",
+        "1 tablespoon fresh lime juice",
+        "1 teaspoon sugar or honey (optional, adjust to taste)",
+        "Ice cubes"
+      ],
+      "steps": [
+        "Peel the rambutans: Use a small knife to carefully cut through the skin around the middle of the fruit, or use your fingernails to tear it open. Remove the translucent flesh from the seed. Discard the skin and seed.",
+        "In a blender, combine the peeled rambutan flesh, fresh pineapple chunks, cold water (or coconut water for extra tropical flavor), and fresh lime juice.",
+        "Add sugar or honey if desired, depending on the sweetness of your fruits.",
+        "Blend the mixture until smooth.",
+        "For an extra smooth drink, you can strain the blended mixture through a fine-mesh sieve to remove any pulp, though this is optional.",
+        "Fill glasses with ice cubes and pour the rambutan and pineapple cooler over the ice.",
+        "Garnish with a slice of lime, a pineapple wedge, or a whole rambutan on the rim of the glass if desired. Serve immediately."
+      ]
+    }
+  ]
+}

--- a/src/lib/data/fruits/rose-apple.json
+++ b/src/lib/data/fruits/rose-apple.json
@@ -1,0 +1,164 @@
+{
+  "id": "rose-apple",
+  "commonName": "Rose Apple",
+  "scientificName": "Syzygium jambos",
+  "image": "https://upload.wikimedia.org/wikipedia/commons/thumb/9/93/Syzygium_jambos.JPG/800px-Syzygium_jambos.JPG",
+  "description": "Syzygium jambos, commonly known as the Rose Apple, is a tropical tree producing bell-shaped to ovoid fruits. The fruit is prized for its crisp, somewhat dry yet juicy flesh, distinctive rose-like aroma, and subtly sweet flavor. The thin, waxy skin is typically pale yellow or whitish, sometimes with a pink blush.",
+  "origin": "Southeast Asia",
+  "localNames": [
+    "Malabar Plum (English)",
+    "Pomarrosa (Spanish)",
+    "Jambu Mawar (Malay/Indonesian)",
+    "Chomphu Namdokmai (ชมพู่น้ำดอกไม้ - Thai)",
+    "Gulab Jamun (Hindi - also name of a sweet)",
+    "Pannerale (Kannada)"
+  ],
+  "regions": [
+    "Southeast Asia (Malaysia, Indonesia, Thailand, Vietnam, Philippines)",
+    "India",
+    "Sri Lanka",
+    "Caribbean Islands (Puerto Rico, Jamaica)",
+    "Central America (Panama, Costa Rica)",
+    "South America (Brazil, Venezuela, Suriname)",
+    "Australia (Queensland)",
+    "United States (Florida, Hawaii, California - limited)"
+  ],
+  "seasons": [
+    "Late spring through summer in many tropical and subtropical regions; can have multiple smaller fruiting seasons depending on local climate and rainfall patterns."
+  ],
+  "nutrition": {
+    "calories": "25 kcal per 100g",
+    "macronutrients": [
+      {
+        "name": "Protein",
+        "value": 0.6,
+        "unit": "g"
+      },
+      {
+        "name": "Carbohydrates",
+        "value": 5.7,
+        "unit": "g"
+      },
+      {
+        "name": "Fat",
+        "value": 0.3,
+        "unit": "g"
+      },
+      {
+        "name": "Fiber",
+        "value": 0.7,
+        "unit": "g"
+      }
+    ],
+    "vitamins": [
+      {
+        "name": "Vitamin C",
+        "value": 22.3,
+        "unit": "mg",
+        "rdi": "25%"
+      },
+      {
+        "name": "Vitamin A",
+        "value": 17,
+        "unit": "µg",
+        "rdi": "2%"
+      },
+      {
+        "name": "Niacin (B3)",
+        "value": 0.8,
+        "unit": "mg",
+        "rdi": "5%"
+      },
+      {
+        "name": "Riboflavin (B2)",
+        "value": 0.03,
+        "unit": "mg",
+        "rdi": "2%"
+      },
+      {
+        "name": "Thiamin (B1)",
+        "value": 0.02,
+        "unit": "mg",
+        "rdi": "2%"
+      }
+    ],
+    "minerals": [
+      {
+        "name": "Potassium",
+        "value": 123,
+        "unit": "mg",
+        "rdi": "3%" 
+      },
+      {
+        "name": "Calcium",
+        "value": 29,
+        "unit": "mg",
+        "rdi": "2%"
+      },
+      {
+        "name": "Iron",
+        "value": 0.07,
+        "unit": "mg",
+        "rdi": "0%"
+      },
+      {
+        "name": "Magnesium",
+        "value": 5,
+        "unit": "mg",
+        "rdi": "1%"
+      },
+      {
+        "name": "Manganese",
+        "value": 0.029,
+        "unit": "mg",
+        "rdi": "1%"
+      },
+      {
+        "name": "Phosphorus",
+        "value": 8,
+        "unit": "mg",
+        "rdi": "1%"
+      }
+    ]
+  },
+  "healthBenefits": [
+    "Good source of Vitamin C, an antioxidant that supports immune function and skin health.",
+    "Provides some dietary fiber, which can aid in digestion.",
+    "The fruit is hydrating due to its high water content."
+  ],
+  "potentialAllergies": [
+    {
+      "name": "Seed Ingestion",
+      "severity": "Low to Moderate",
+      "details": "The seeds are generally considered inedible and may contain small amounts of cyanogenic compounds. It is advisable to avoid consuming the seeds. The fruit flesh itself is widely consumed and well-tolerated."
+    }
+  ],
+  "cultivationProcess": "Rose Apple trees (Syzygium jambos) are adaptable evergreens that thrive in tropical and warm subtropical climates. They prefer moist, well-drained soil and can grow in full sun to partial shade. Propagation is often done by seeds (which have short viability), air layering, or budding. Trees are relatively low-maintenance once established but benefit from regular watering, especially during dry periods and fruit development. Pruning can help manage tree size and encourage airflow.",
+  "growthDuration": "Rose Apple trees typically start bearing fruit within 3 to 5 years from planting. They are medium-sized trees that can reach heights of 3-15 meters. Fruiting may occur multiple times a year in favorable tropical climates.",
+  "sustainabilityTips": [
+    "Rose apple trees are often grown in home gardens and as ornamental trees, contributing to local food availability and green spaces.",
+    "Their adaptability to various soil types can make them a resilient fruit tree choice in suitable climates, potentially requiring fewer inputs than more demanding species."
+  ],
+  "carbonFootprintInfo": "Locally grown and consumed rose apples have a minimal carbon footprint. Due to their delicate nature and relatively short shelf life once ripe, long-distance transportation for fresh consumption, especially by air freight, would significantly increase their environmental impact.",
+  "staticRecipes": [
+    {
+      "name": "Rose Apple & Toasted Coconut Salad",
+      "description": "A light and refreshing salad that highlights the crisp texture and delicate rose-like aroma of fresh rose apples, complemented by the nuttiness of toasted coconut.",
+      "ingredients": [
+        "4-5 fresh rose apples",
+        "2 tablespoons toasted shredded coconut (unsweetened)",
+        "1 tablespoon fresh lime juice",
+        "1 teaspoon honey or agave nectar (optional, to taste)",
+        "A few fresh mint leaves, chopped (for garnish)"
+      ],
+      "steps": [
+        "Wash the rose apples thoroughly. They can be eaten whole after removing the stem end, or sliced. The core usually contains 1-2 loose, inedible seeds which should be discarded.",
+        "Slice the rose apples into bite-sized pieces or thin wedges. The skin is edible and typically left on.",
+        "In a medium bowl, gently toss the sliced rose apples with the fresh lime juice. If using, drizzle with honey or agave nectar and toss again.",
+        "Sprinkle the toasted shredded coconut over the rose apple mixture.",
+        "Garnish with freshly chopped mint leaves.",
+        "Serve immediately to enjoy the crisp texture and fragrant aroma. This salad is best made just before serving."
+      ]
+    }
+  ]
+}

--- a/src/lib/data/fruits/sapodilla.json
+++ b/src/lib/data/fruits/sapodilla.json
@@ -1,0 +1,171 @@
+{
+  "id": "sapodilla",
+  "commonName": "Sapodilla",
+  "scientificName": "Manilkara zapota",
+  "image": "https://upload.wikimedia.org/wikipedia/commons/thumb/7/70/Sapodilla_Malay_with_seeds.jpg/800px-Sapodilla_Malay_with_seeds.jpg",
+  "description": "Sapodilla (Manilkara zapota) is a tropical evergreen tree that produces a sweet, malty-flavored fruit with a grainy texture, similar to a pear. The fruit is round to oval, with a dull brown, rough skin. The flesh is pale yellow to an earthy brown and contains a few glossy black seeds.",
+  "origin": "Native to southern Mexico, Central America, and the Caribbean.",
+  "localNames": [
+    "Chikoo (India, Pakistan)",
+    "Chico (Philippines)",
+    "Naseberry (Caribbean)",
+    "Sapote (general term, can be ambiguous)",
+    "Níspero (some Spanish-speaking regions, can be ambiguous)",
+    "Sawo (Indonesia, Malaysia)"
+  ],
+  "regions": [
+    "Mexico",
+    "Central America (Belize, Guatemala)",
+    "Caribbean Islands (Jamaica, Bahamas)",
+    "India (major producer)",
+    "Pakistan",
+    "Thailand",
+    "Malaysia",
+    "Indonesia",
+    "Vietnam",
+    "Bangladesh",
+    "Philippines",
+    "United States (Florida, Hawaii)"
+  ],
+  "seasons": [
+    "Can fruit twice a year in many tropical regions, with main seasons varying (e.g., typically February to June and September to December in some parts of India and Southeast Asia)."
+  ],
+  "nutrition": {
+    "calories": "83 kcal per 100g",
+    "macronutrients": [
+      {
+        "name": "Protein",
+        "value": 0.44,
+        "unit": "g"
+      },
+      {
+        "name": "Carbohydrates",
+        "value": 19.96,
+        "unit": "g"
+      },
+      {
+        "name": "Fat",
+        "value": 1.1,
+        "unit": "g"
+      },
+      {
+        "name": "Fiber",
+        "value": 5.3,
+        "unit": "g"
+      }
+    ],
+    "vitamins": [
+      {
+        "name": "Vitamin C",
+        "value": 14.7,
+        "unit": "mg",
+        "rdi": "16%"
+      },
+      {
+        "name": "Folate (B9)",
+        "value": 14,
+        "unit": "µg",
+        "rdi": "4%"
+      },
+      {
+        "name": "Pantothenic acid (B5)",
+        "value": 0.252,
+        "unit": "mg",
+        "rdi": "5%"
+      },
+      {
+        "name": "Vitamin B6",
+        "value": 0.037,
+        "unit": "mg",
+        "rdi": "2%"
+      },
+      {
+        "name": "Niacin (B3)",
+        "value": 0.2,
+        "unit": "mg",
+        "rdi": "1%"
+      },
+      {
+        "name": "Riboflavin (B2)",
+        "value": 0.02,
+        "unit": "mg",
+        "rdi": "2%"
+      }
+    ],
+    "minerals": [
+      {
+        "name": "Potassium",
+        "value": 193,
+        "unit": "mg",
+        "rdi": "6%"
+      },
+      {
+        "name": "Iron",
+        "value": 0.8,
+        "unit": "mg",
+        "rdi": "4%"
+      },
+      {
+        "name": "Calcium",
+        "value": 21,
+        "unit": "mg",
+        "rdi": "2%"
+      },
+      {
+        "name": "Magnesium",
+        "value": 12,
+        "unit": "mg",
+        "rdi": "3%"
+      },
+      {
+        "name": "Phosphorus",
+        "value": 12,
+        "unit": "mg",
+        "rdi": "1%"
+      }
+    ]
+  },
+  "healthBenefits": [
+    "Excellent source of dietary fiber, which aids in digestion, helps prevent constipation, and can contribute to feelings of fullness.",
+    "Good source of Vitamin C, an antioxidant that supports the immune system and helps protect against free radical damage.",
+    "Contains tannins (especially when slightly unripe), which have traditionally been thought to possess anti-inflammatory and anti-parasitic properties."
+  ],
+  "potentialAllergies": [
+    {
+      "name": "Latex in unripe fruit",
+      "severity": "Mild",
+      "details": "Unripe sapodilla fruit contains a high amount of latex and saponins, which are astringent and can cause mouth irritation or dryness. Fully ripe fruit does not have this issue. Seeds are hard and have a small hook, and should not be swallowed."
+    }
+  ],
+  "cultivationProcess": "Sapodilla trees are long-lived, wind-resistant evergreens that thrive in warm, tropical, and subtropical climates. They prefer well-drained soil and full sun. Propagation is commonly done by seeds (though trees take longer to mature), grafting, or air layering to ensure desired fruit quality. The tree's bark contains a white, gummy latex called chicle, famously used for chewing gum. Trees are relatively low-maintenance once established.",
+  "growthDuration": "Sapodilla trees grown from seed may take 5 to 8 years to bear fruit, while grafted or layered trees can start fruiting in 2 to 4 years. The trees can be productive for many decades and may yield fruit twice a year in some regions.",
+  "sustainabilityTips": [
+    "Sapodilla trees are hardy and can be grown with relatively few inputs in suitable climates, making them a sustainable choice for local fruit production.",
+    "The traditional use of its latex (chicle) for natural chewing gum represents a sustainable, non-timber forest product when harvested responsibly."
+  ],
+  "carbonFootprintInfo": "Locally grown sapodilla has a relatively low carbon footprint. However, due to its preference for tropical climates, sapodilla imported to temperate regions often involves long-distance transportation, increasing its environmental impact, especially if air-freighted to maintain freshness.",
+  "staticRecipes": [
+    {
+      "name": "Creamy Sapodilla (Chikoo) Milkshake",
+      "description": "A sweet, rich, and creamy milkshake made from ripe sapodilla fruit, a popular and refreshing beverage in many tropical countries where the fruit is grown.",
+      "ingredients": [
+        "2 large ripe sapodillas (chikoo), peeled, deseeded, and roughly chopped",
+        "1 cup cold milk (dairy like whole milk, or non-dairy like almond or soy milk)",
+        "1-2 teaspoons sugar or honey (optional, adjust to the sweetness of the fruit)",
+        "1/4 teaspoon ground cardamom powder (elaichi) (optional)",
+        "4-5 ice cubes (optional, for a thicker shake)"
+      ],
+      "steps": [
+        "Ensure the sapodillas are fully ripe (soft to a gentle squeeze, skin may look slightly wrinkled).",
+        "Wash the sapodillas, peel off the brown skin, and cut them in half.",
+        "Remove and discard the hard, black, shiny seeds from the center of each half.",
+        "Roughly chop the sapodilla flesh.",
+        "Place the chopped sapodilla, cold milk, sugar or honey (if using), and optional cardamom powder into a blender.",
+        "Add the ice cubes if you desire a colder and thicker milkshake.",
+        "Blend the mixture on high speed for 1-2 minutes, or until it is completely smooth and creamy. If the milkshake is too thick for your liking, add a little more milk and blend briefly to reach the desired consistency.",
+        "Pour the sapodilla milkshake into serving glasses.",
+        "Serve immediately. You can garnish with a pinch of cardamom powder or a thin slice of sapodilla on the rim of the glass if desired."
+      ]
+    }
+  ]
+}

--- a/src/lib/data/fruits/surinam-cherry.json
+++ b/src/lib/data/fruits/surinam-cherry.json
@@ -1,0 +1,156 @@
+{
+  "id": "surinam-cherry",
+  "commonName": "Surinam Cherry",
+  "scientificName": "Eugenia uniflora",
+  "image": "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a5/Eugenia_uniflora_fruits.jpg/800px-Eugenia_uniflora_fruits.jpg",
+  "description": "The Surinam Cherry (Eugenia uniflora) is a tropical shrub or small tree that produces distinctive ribbed fruits. The fruit transitions from green to orange, scarlet, and finally deep maroon or nearly black when fully ripe. Its flavor profile ranges from tart to sweet, often with a resinous or spicy note, depending on ripeness and cultivar.",
+  "origin": "Tropical South America's east coast (Suriname, French Guiana, southern Brazil, Uruguay, parts of Paraguay and Argentina).",
+  "localNames": [
+    "Pitanga (Brazil, and widely used)",
+    "Brazilian Cherry (English)",
+    "Cayenne Cherry (English)",
+    "Ñangapirí (Guarani)",
+    "Cerise Carrée (French Caribbean)"
+  ],
+  "regions": [
+    "South America (Brazil, Suriname, French Guiana, Uruguay, Paraguay, Argentina)",
+    "Caribbean Islands (Barbados, Jamaica, Puerto Rico)",
+    "United States (Florida, Hawaii, California - primarily ornamental or home gardens)",
+    "Bermuda (naturalized, invasive)",
+    "Parts of Asia and Africa (introduced as ornamental and for fruit)"
+  ],
+  "seasons": [
+    "Can flower and fruit multiple times a year in warm climates, with main fruiting peaks often occurring in spring and fall."
+  ],
+  "nutrition": {
+    "calories": "33 kcal per 100g",
+    "macronutrients": [
+      {
+        "name": "Protein",
+        "value": 0.8,
+        "unit": "g"
+      },
+      {
+        "name": "Carbohydrates",
+        "value": 7.49,
+        "unit": "g"
+      },
+      {
+        "name": "Fat",
+        "value": 0.4,
+        "unit": "g"
+      },
+      {
+        "name": "Fiber",
+        "value": 0.6,
+        "unit": "g"
+      }
+    ],
+    "vitamins": [
+      {
+        "name": "Vitamin C",
+        "value": 26.3,
+        "unit": "mg",
+        "rdi": "29%"
+      },
+      {
+        "name": "Vitamin A",
+        "value": 75,
+        "unit": "µg",
+        "rdi": "8%"
+      },
+      {
+        "name": "Niacin (B3)",
+        "value": 0.3,
+        "unit": "mg",
+        "rdi": "2%"
+      },
+      {
+        "name": "Riboflavin (B2)",
+        "value": 0.04,
+        "unit": "mg",
+        "rdi": "3%"
+      },
+      {
+        "name": "Thiamin (B1)",
+        "value": 0.03,
+        "unit": "mg",
+        "rdi": "3%"
+      }
+    ],
+    "minerals": [
+      {
+        "name": "Potassium",
+        "value": 103,
+        "unit": "mg",
+        "rdi": "2%" 
+      },
+      {
+        "name": "Calcium",
+        "value": 9,
+        "unit": "mg",
+        "rdi": "1%"
+      },
+      {
+        "name": "Iron",
+        "value": 0.2,
+        "unit": "mg",
+        "rdi": "1%"
+      },
+      {
+        "name": "Magnesium",
+        "value": 12,
+        "unit": "mg",
+        "rdi": "3%"
+      },
+      {
+        "name": "Phosphorus",
+        "value": 11,
+        "unit": "mg",
+        "rdi": "1%"
+      }
+    ]
+  },
+  "healthBenefits": [
+    "Rich in Vitamin C, a powerful antioxidant that supports the immune system and collagen formation.",
+    "Good source of Vitamin A (as carotenoids), which is important for vision health, immune function, and cell growth.",
+    "Contains various phytochemicals and essential oils that have shown antioxidant, anti-inflammatory, and other potential pharmacological properties in studies."
+  ],
+  "potentialAllergies": [
+    {
+      "name": "Seed Ingestion / Leaf Resin",
+      "severity": "Mild to Moderate",
+      "details": "The seeds contain resin and are generally not consumed. The leaves and branches have a spicy, resinous fragrance when crushed that can cause respiratory discomfort in susceptible individuals. The fruit itself is widely eaten."
+    }
+  ],
+  "cultivationProcess": "Surinam Cherry (Eugenia uniflora) is a hardy and adaptable large shrub or small tree, often used as a hedge or ornamental plant. It thrives in tropical and subtropical climates, tolerating a range of soil types provided they are well-drained. Propagation can be from seeds (though fruit quality may vary) or more reliably from cuttings or air layering for specific cultivars. It responds well to pruning and can be shaped easily. It is relatively pest and disease resistant in many areas.",
+  "growthDuration": "Plants can start fruiting within 2-3 years from seed, and often earlier if propagated vegetatively. They are slow-growing, typically reaching up to 8 meters in height, and can produce fruit multiple times a year in favorable conditions.",
+  "sustainabilityTips": [
+    "Due to its hardiness and adaptability, Surinam cherry can be grown with minimal pesticide or fertilizer use in suitable climates, making it an eco-friendly choice for home gardens.",
+    "Often used for hedging, it can provide both fruit and a natural boundary, supporting local biodiversity."
+  ],
+  "carbonFootprintInfo": "Surinam cherries grown and consumed locally (e.g., in home gardens or small local farms) have a very low carbon footprint. If the fruit needs to be transported long distances, especially by air to reach markets where it's not locally grown, the carbon footprint would increase significantly.",
+  "staticRecipes": [
+    {
+      "name": "Simple Surinam Cherry Jam",
+      "description": "A delightful jam that captures the unique sweet-tart and slightly resinous flavor of Surinam cherries. Excellent on toast, with yogurt, or as a glaze.",
+      "ingredients": [
+        "500g ripe Surinam cherries, pitted",
+        "400g granulated sugar (adjust to taste, as ripeness affects sweetness)",
+        "Juice of 1/2 lemon (about 1-2 tablespoons)"
+      ],
+      "steps": [
+        "Wash the ripe Surinam cherries thoroughly. Remove the stems. The single seed in the center can be easily popped out by gently squeezing the fruit, or by halving the fruit and removing it.",
+        "Place the pitted Surinam cherries and granulated sugar into a large, heavy-bottomed saucepan. Stir gently to combine.",
+        "Let the mixture sit at room temperature for at least 1 hour, or up to 4 hours, stirring occasionally. This allows the sugar to draw out juices from the fruit.",
+        "Add the lemon juice to the fruit and sugar mixture.",
+        "Place the saucepan over medium-low heat. Cook, stirring gently and continuously, until the sugar has completely dissolved. Do not allow the mixture to boil before the sugar is dissolved.",
+        "Once the sugar is fully dissolved, increase the heat to medium-high and bring the mixture to a rolling boil (a boil that continues even when you stir).",
+        "Continue to boil rapidly, stirring frequently to prevent sticking, for about 15-25 minutes. The cooking time will vary depending on the ripeness of the fruit and desired thickness. To test for setting point, remove the pan from heat, place a small spoonful of jam onto a chilled saucer (kept in the freezer for a few minutes), let it cool for 30 seconds, then push it with your fingertip. If the surface wrinkles, the jam is set. Alternatively, use a jam thermometer – setting point is 105°C (221°F).",
+        "Once the setting point is reached, remove the jam from the heat. Skim off any foam (scum) from the surface using a slotted spoon, if desired, for a clearer jam.",
+        "Carefully ladle the hot jam into warm, sterilized glass jars, leaving about 1/4 inch (0.5 cm) of headspace at the top.",
+        "Wipe the jar rims clean with a damp cloth, place the lids on, and tighten the screw bands securely. Allow the jars to cool completely undisturbed. As the jam cools, you should hear the lids 'pop', indicating a good seal. The jam will thicken further as it cools."
+      ]
+    }
+  ]
+}

--- a/src/lib/data/vegetables/amaranth-leaves.json
+++ b/src/lib/data/vegetables/amaranth-leaves.json
@@ -1,0 +1,175 @@
+{
+  "id": "amaranth-leaves",
+  "commonName": "Amaranth Leaves",
+  "scientificName": "Amaranthus spp. (Leafy Varieties, e.g., A. tricolor, A. viridis, A. cruentus)",
+  "image": "https://upload.wikimedia.org/wikipedia/commons/7/7e/Red_Callaloo.jpg",
+  "description": "Amaranth leaves are the edible foliage of various species within the Amaranthus genus. These highly nutritious leafy greens are popular in many global cuisines, known for their mild, slightly sweet or earthy flavor and tender texture when cooked. Leaf colors range from green to vibrant red and variegated.",
+  "origin": "Cosmopolitan, with different species native to the Americas, Asia, and Africa. Cultivation for leaves is ancient in many tropical and subtropical regions.",
+  "localNames": [
+    "Chinese Spinach (English common name)",
+    "Callaloo (Caribbean)",
+    "Tampala (India)",
+    "Chaulai Saag (Hindi)",
+    "Bayam (Malay/Indonesian)",
+    "Kulitis (Tagalog)",
+    "Rau dền (Vietnamese)"
+  ],
+  "regions": [
+    "Asia (India, China, Indonesia, Philippines, Vietnam, Malaysia, Sri Lanka)",
+    "Africa (Nigeria, Uganda, Kenya, Botswana)",
+    "Caribbean Islands (Jamaica, Trinidad and Tobago)",
+    "South America (Brazil)",
+    "Europe (Greece)"
+  ],
+  "seasons": [
+    "Primarily warm seasons (Spring, Summer, early Autumn) in most regions. Some species are very hardy and can have extended growing seasons or be grown year-round in tropical climates."
+  ],
+  "nutrition": {
+    "calories": "21 kcal per 100g (cooked, boiled, drained)",
+    "macronutrients": [
+      {
+        "name": "Protein",
+        "value": 2.05,
+        "unit": "g"
+      },
+      {
+        "name": "Carbohydrates",
+        "value": 3.71,
+        "unit": "g"
+      },
+      {
+        "name": "Fat",
+        "value": 0.19,
+        "unit": "g"
+      },
+      {
+        "name": "Fiber",
+        "value": 2.1,
+        "unit": "g"
+      }
+    ],
+    "vitamins": [
+      {
+        "name": "Vitamin K",
+        "value": 1140,
+        "unit": "µg",
+        "rdi": "950%"
+      },
+      {
+        "name": "Vitamin C",
+        "value": 43.3,
+        "unit": "mg",
+        "rdi": "48%"
+      },
+      {
+        "name": "Vitamin A",
+        "value": 292,
+        "unit": "µg RAE",
+        "rdi": "32%"
+      },
+      {
+        "name": "Folate (B9)",
+        "value": 85,
+        "unit": "µg",
+        "rdi": "21%"
+      },
+      {
+        "name": "Riboflavin (B2)",
+        "value": 0.158,
+        "unit": "mg",
+        "rdi": "12%"
+      },
+      {
+        "name": "Vitamin B6",
+        "value": 0.116,
+        "unit": "mg",
+        "rdi": "7%"
+      }
+    ],
+    "minerals": [
+      {
+        "name": "Manganese",
+        "value": 0.851,
+        "unit": "mg",
+        "rdi": "37%"
+      },
+      {
+        "name": "Calcium",
+        "value": 215,
+        "unit": "mg",
+        "rdi": "17%"
+      },
+      {
+        "name": "Potassium",
+        "value": 411,
+        "unit": "mg",
+        "rdi": "9%"
+      },
+      {
+        "name": "Magnesium",
+        "value": 55,
+        "unit": "mg",
+        "rdi": "13%"
+      },
+      {
+        "name": "Iron",
+        "value": 2.1,
+        "unit": "mg",
+        "rdi": "12%"
+      },
+      {
+        "name": "Phosphorus",
+        "value": 50, 
+        "unit": "mg",
+        "rdi": "4%"
+      }
+    ]
+  },
+  "healthBenefits": [
+    "Exceptionally rich in Vitamin K, crucial for blood clotting and bone metabolism.",
+    "Excellent source of Vitamin A (as carotenoids) and Vitamin C, both potent antioxidants that support immune function, vision, and skin health.",
+    "Provides significant amounts of essential minerals including calcium for bone health, manganese for metabolic function, and iron for oxygen transport."
+  ],
+  "potentialAllergies": [
+    {
+      "name": "Oxalates",
+      "severity": "Low to Moderate",
+      "details": "Amaranth leaves contain oxalates, which may contribute to kidney stone formation in susceptible individuals if consumed in very large quantities regularly. Cooking can help reduce oxalate levels."
+    },
+    {
+      "name": "Nitrates",
+      "severity": "Low",
+      "details": "Like many leafy greens, amaranth can accumulate nitrates from the soil. While generally not an issue for most, very high intake by infants or certain individuals could be a concern."
+    }
+  ],
+  "cultivationProcess": "Amaranth grown for its leaves is typically a fast-growing annual plant. It is adaptable to various soil types but thrives in well-drained, fertile soil with full sun exposure. Seeds can be sown directly into the ground or started indoors for transplanting. Amaranth is known for its heat tolerance and can often be harvested multiple times using the 'cut-and-come-again' method, where outer leaves are taken, allowing inner leaves to continue growing.",
+  "growthDuration": "Ready for first harvest of young leaves typically within 3-6 weeks (20-40 days) from sowing. Mature leaves can be harvested over an extended period, often up to 2-3 months, depending on the species and growing conditions.",
+  "sustainabilityTips": [
+    "Amaranth is a highly resilient and fast-growing crop, often tolerant of drought and poor soil conditions, making it a sustainable choice for diverse agricultural systems.",
+    "It's well-suited for home gardening and small-scale farming, promoting local food security and reducing reliance on transported greens."
+  ],
+  "carbonFootprintInfo": "Locally grown amaranth leaves, especially when cultivated organically or with minimal inputs, have a very low carbon footprint. Commercially grown leaves that require significant transportation, packaging, or out-of-season greenhouse production will have a higher environmental impact.",
+  "staticRecipes": [
+    {
+      "name": "Simple Stir-fried Amaranth Leaves with Garlic",
+      "description": "A quick, nutritious, and flavorful way to prepare amaranth leaves, highlighting their tender texture and mild, slightly earthy taste. A staple in many Asian cuisines.",
+      "ingredients": [
+        "1 large bunch amaranth leaves (about 300-400g), tough stems trimmed or removed",
+        "1-2 tablespoons cooking oil (e.g., vegetable oil, sesame oil, or peanut oil)",
+        "2-4 cloves garlic, minced or thinly sliced",
+        "1/2 teaspoon salt (or to taste)",
+        "Optional: Pinch of sugar, a dash of soy sauce or fish sauce, a sprinkle of white pepper"
+      ],
+      "steps": [
+        "Prepare the amaranth leaves: Wash the leaves thoroughly in several changes of cold water to remove any dirt, sand, or grit. If the stems are particularly thick or fibrous, you can remove them or chop them finely to cook for a bit longer before adding the leaves. Younger, tender stems can be cooked along with the leaves. Shake off excess water.",
+        "Heat the cooking oil in a large skillet, wok, or wide pan over medium-high heat until the oil shimmers.",
+        "Add the minced or sliced garlic to the hot oil. Stir-fry for about 20-30 seconds until the garlic becomes fragrant and lightly golden. Be careful not to burn the garlic, as it can turn bitter.",
+        "Immediately add all the washed amaranth leaves to the skillet. The volume will seem large at first, but the leaves will wilt down significantly.",
+        "Stir-fry continuously, tossing the leaves with the garlic and oil, for about 2-4 minutes. The leaves should wilt quickly and turn a vibrant green. If the pan seems too dry, you can add a tablespoon of water to help steam the leaves and prevent them from scorching.",
+        "Season with salt. If using, add the optional pinch of sugar (to balance flavors) and a dash of soy sauce or fish sauce for umami. Stir well to distribute the seasonings.",
+        "Continue to cook for another 1-2 minutes, or until the leaves are tender to your preference but still retain their bright color. Avoid overcooking, which can make them mushy.",
+        "Remove from heat and transfer to a serving dish. Serve immediately as a nutritious side dish with rice, noodles, or other main courses."
+      ]
+    }
+  ]
+}

--- a/src/lib/data/vegetables/corn.json
+++ b/src/lib/data/vegetables/corn.json
@@ -1,0 +1,178 @@
+{
+  "id": "corn",
+  "commonName": "Sweet Corn",
+  "scientificName": "Zea mays convar. saccharata var. rugosa",
+  "image": "https://upload.wikimedia.org/wikipedia/commons/thumb/f/f0/VegCorn.jpg/800px-VegCorn.jpg",
+  "description": "Sweet corn is a popular variety of maize cherished for its high sugar content. It is harvested at an immature stage (milk stage) when the kernels are tender, juicy, and sweet, and is consumed as a vegetable rather than a grain.",
+  "origin": "Mesoamerica, with specific sweet varieties developed by Native American tribes and further cultivated in North America and worldwide.",
+  "localNames": [
+    "Maíz Dulce (Spanish)",
+    "Maïs Sucré (French)",
+    "Zuckermais (German)",
+    "Elote (Mexican Spanish - for corn on the cob)",
+    "Jagung Manis (Indonesian/Malay)"
+  ],
+  "regions": [
+    "United States (major producer - Iowa, Illinois, Nebraska)",
+    "China",
+    "Brazil",
+    "Mexico",
+    "European Union (France, Hungary, Romania)",
+    "Canada",
+    "Argentina",
+    "South Africa",
+    "Thailand",
+    "India"
+  ],
+  "seasons": [
+    "Summer to early Autumn in temperate climates (typically June to October in the Northern Hemisphere)"
+  ],
+  "nutrition": {
+    "calories": "86 kcal per 100g",
+    "macronutrients": [
+      {
+        "name": "Protein",
+        "value": 3.27,
+        "unit": "g"
+      },
+      {
+        "name": "Carbohydrates",
+        "value": 18.7,
+        "unit": "g"
+      },
+      {
+        "name": "Fat",
+        "value": 1.35,
+        "unit": "g"
+      },
+      {
+        "name": "Fiber",
+        "value": 2.0,
+        "unit": "g"
+      }
+    ],
+    "vitamins": [
+      {
+        "name": "Vitamin C",
+        "value": 6.8,
+        "unit": "mg",
+        "rdi": "8%"
+      },
+      {
+        "name": "Thiamin (B1)",
+        "value": 0.155,
+        "unit": "mg",
+        "rdi": "13%"
+      },
+      {
+        "name": "Niacin (B3)",
+        "value": 1.77,
+        "unit": "mg",
+        "rdi": "11%"
+      },
+      {
+        "name": "Folate (B9)",
+        "value": 42,
+        "unit": "µg",
+        "rdi": "11%"
+      },
+      {
+        "name": "Vitamin B6",
+        "value": 0.093,
+        "unit": "mg",
+        "rdi": "5%"
+      },
+      {
+        "name": "Vitamin A",
+        "value": 10, 
+        "unit": "µg", 
+        "rdi": "1%"
+      },
+      {
+        "name": "Vitamin K",
+        "value": 0.3,
+        "unit": "µg",
+        "rdi": "0%"
+      }
+    ],
+    "minerals": [
+      {
+        "name": "Potassium",
+        "value": 270,
+        "unit": "mg",
+        "rdi": "6%"
+      },
+      {
+        "name": "Magnesium",
+        "value": 37,
+        "unit": "mg",
+        "rdi": "9%"
+      },
+      {
+        "name": "Phosphorus",
+        "value": 89,
+        "unit": "mg",
+        "rdi": "7%"
+      },
+      {
+        "name": "Iron",
+        "value": 0.52,
+        "unit": "mg",
+        "rdi": "3%"
+      },
+      {
+        "name": "Zinc",
+        "value": 0.46,
+        "unit": "mg",
+        "rdi": "4%"
+      },
+      {
+        "name": "Manganese",
+        "value": 0.163,
+        "unit": "mg",
+        "rdi": "7%"
+      }
+    ]
+  },
+  "healthBenefits": [
+    "Good source of dietary fiber, which promotes digestive health and can help regulate blood sugar levels.",
+    "Provides essential nutrients including B vitamins (Thiamin, Niacin, Folate, B6) important for energy metabolism and neurological health.",
+    "Contains antioxidants like Vitamin C and ferulic acid (which increases upon cooking) that help protect cells from damage."
+  ],
+  "potentialAllergies": [
+    {
+      "name": "Corn Allergy",
+      "severity": "Varies (Mild to Severe)",
+      "details": "While not as common as some other food allergies, corn allergy can occur. Symptoms can range from hives, digestive issues, or asthma-like symptoms to severe anaphylaxis in highly sensitive individuals."
+    }
+  ],
+  "cultivationProcess": "Sweet corn is an annual crop grown from seeds planted in warm soil after the danger of frost has passed. It requires full sun, fertile well-drained soil, and consistent moisture, especially during pollination and kernel development. Corn is wind-pollinated, so it's often planted in blocks rather than single rows. Different types of sweet corn (standard sugary (su), sugary enhanced (se), shrunken-2 (sh2)) may require isolation from each other and field corn to prevent cross-pollination that can affect sweetness and texture.",
+  "growthDuration": "Typically 60 to 100 days from planting to harvest, depending on the specific cultivar and growing conditions. Sweet corn is harvested at the 'milk stage,' when kernels are plump, sweet, and exude a milky liquid when pierced.",
+  "sustainabilityTips": [
+    "Practice crop rotation with legumes to improve soil fertility naturally and reduce the need for synthetic nitrogen fertilizers.",
+    "Choose open-pollinated or heirloom varieties for seed saving and to support agricultural biodiversity, though hybrid varieties often offer higher yields and disease resistance."
+  ],
+  "carbonFootprintInfo": "Fresh sweet corn grown locally and consumed in season generally has a relatively low carbon footprint. However, processed corn (canned, frozen) and corn transported long distances (especially out of season) will have a higher footprint due to energy used in processing, packaging, and transportation.",
+  "staticRecipes": [
+    {
+      "name": "Classic Grilled Corn on the Cob",
+      "description": "A quintessential summer side dish where fresh sweet corn is grilled to perfection, enhancing its natural sweetness with a delightful smoky char.",
+      "ingredients": [
+        "4 ears of fresh sweet corn",
+        "2 tablespoons butter, melted (optional)",
+        "Salt to taste",
+        "Black pepper to taste (optional)",
+        "Optional flavorings: chili powder, lime wedges, crumbled cotija cheese, chopped cilantro"
+      ],
+      "steps": [
+        "Preheat your grill to medium-high heat (around 375-450°F or 190-230°C).",
+        "Prepare the corn: You can either remove the husks and silk completely for direct grilling, or carefully pull back the husks, remove all the silk, then reposition the husks over the corn to help steam it (soaking these husked ears in water for 10-15 minutes beforehand can prevent the husks from burning too quickly).",
+        "Grill the corn: Place the prepared corn directly on the hot grill grates.",
+        "Cook for 10-15 minutes, turning the ears every few minutes, until the kernels are tender and nicely charred in spots. If grilling with husks on, the husks will char significantly – this is normal.",
+        "Rest briefly: If you grilled with the husks on, allow the corn to cool for a few minutes before carefully removing the charred husks and any remaining silk.",
+        "Season: If using, brush the hot grilled corn cobs with melted butter. Season generously with salt and black pepper.",
+        "Serve: Serve immediately while warm. Offer optional flavorings on the side like chili powder, fresh lime wedges for squeezing, crumbled cotija cheese, or chopped cilantro."
+      ]
+    }
+  ]
+}

--- a/src/lib/data/vegetables/curry-leaves.json
+++ b/src/lib/data/vegetables/curry-leaves.json
@@ -1,0 +1,143 @@
+{
+  "id": "curry-leaves",
+  "commonName": "Curry Leaves",
+  "scientificName": "Bergera koenigii (syn. Murraya koenigii)",
+  "image": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/47/Fresh_curry_Leaf_%2849697684423%29.jpg/800px-Fresh_curry_Leaf_%2849697684423%29.jpg",
+  "description": "Curry leaves are the highly aromatic leaves of the curry tree (Bergera koenigii). They are a staple in South Indian, Sri Lankan, and Southeast Asian cuisines, prized for their unique, pungent aroma and slightly bitter, citrusy flavor. They are typically used fresh at the beginning of cooking, often fried in oil to release their essence into a dish.",
+  "origin": "Indian subcontinent (India, Sri Lanka).",
+  "localNames": [
+    "Kadi Patta (Hindi)",
+    "Karuveppilai (Tamil)",
+    "Karivepaku (Telugu)",
+    "Limda / Meetho Limdo (Gujarati)",
+    "Karapincha (Sinhalese)",
+    "Daun Kari (Malay/Indonesian)"
+  ],
+  "regions": [
+    "India (especially Southern and Western states)",
+    "Sri Lanka",
+    "Malaysia",
+    "Singapore",
+    "Thailand",
+    "Bangladesh",
+    "Myanmar",
+    "Widely cultivated in tropical and subtropical regions worldwide, including parts of Australia, Africa, and the Americas where there is an Indian diaspora."
+  ],
+  "seasons": [
+    "Available year-round from trees in tropical climates. Leaves can be harvested as needed once the plant is established."
+  ],
+  "nutrition": {
+    "calories": "108 kcal per 100g (raw)",
+    "macronutrients": [
+      {
+        "name": "Protein",
+        "value": 6.1,
+        "unit": "g"
+      },
+      {
+        "name": "Carbohydrates",
+        "value": 18.7,
+        "unit": "g"
+      },
+      {
+        "name": "Fat",
+        "value": 1.0,
+        "unit": "g"
+      },
+      {
+        "name": "Fiber",
+        "value": 6.4,
+        "unit": "g"
+      }
+    ],
+    "vitamins": [
+      {
+        "name": "Vitamin A",
+        "value": 600,
+        "unit": "µg RAE",
+        "rdi": "67%"
+      },
+      {
+        "name": "Vitamin C",
+        "value": 4,
+        "unit": "mg",
+        "rdi": "4%"
+      },
+      {
+        "name": "Vitamin B6",
+        "value": 0.11,
+        "unit": "mg",
+        "rdi": "6%"
+      }
+    ],
+    "minerals": [
+      {
+        "name": "Calcium",
+        "value": 830,
+        "unit": "mg",
+        "rdi": "64%"
+      },
+      {
+        "name": "Potassium",
+        "value": 540,
+        "unit": "mg",
+        "rdi": "11%"
+      },
+      {
+        "name": "Iron",
+        "value": 0.93,
+        "unit": "mg",
+        "rdi": "5%"
+      },
+      {
+        "name": "Phosphorus",
+        "value": 57,
+        "unit": "mg",
+        "rdi": "5%"
+      }
+    ]
+  },
+  "healthBenefits": [
+    "Rich source of Vitamin A (from carotenoids), essential for good vision and immune function.",
+    "Excellent source of calcium, crucial for bone health and various physiological processes.",
+    "Traditionally used in Ayurvedic medicine to aid digestion, manage diabetes, and for their antioxidant properties due to various plant compounds."
+  ],
+  "potentialAllergies": [
+    {
+      "name": "Contact Dermatitis (rare)",
+      "severity": "Mild",
+      "details": "Handling the plant or its sap may cause skin irritation in highly sensitive individuals. Allergic reactions to consuming cooked curry leaves are very rare."
+    }
+  ],
+  "cultivationProcess": "Curry leaf trees are tropical to subtropical small trees or shrubs. They can be propagated from seeds (though germination can be slow), root suckers, or stem cuttings. They thrive in well-drained soil, prefer full sun to partial shade, and require regular watering, especially when young. Once established, they are relatively hardy. Leaves can be harvested as needed throughout the year.",
+  "growthDuration": "Plants grown from seeds may take 1-2 years to become established enough for regular harvesting. Vegetative propagation can lead to faster establishment. Mature plants provide a continuous supply of leaves.",
+  "sustainabilityTips": [
+    "Growing a curry leaf plant in a pot or garden (in suitable climates) is very sustainable, providing fresh leaves as needed and eliminating packaging and transport.",
+    "Fresh leaves offer the best flavor; they can also be air-dried or frozen for longer storage, reducing waste."
+  ],
+  "carbonFootprintInfo": "Fresh curry leaves picked from a home garden or sourced locally have a negligible carbon footprint. Commercially packaged leaves, especially those transported long distances (sometimes internationally) or requiring refrigeration, will have a higher environmental impact.",
+  "staticRecipes": [
+    {
+      "name": "Basic South Indian Tempering (Tadka/Thaalithal)",
+      "description": "A fundamental flavoring technique in South Indian cooking where spices, including fresh curry leaves, are briefly fried in oil or ghee to release their aromas before being added to a dish like dal, sambar, chutney, or vegetable stir-fries.",
+      "ingredients": [
+        "1 tablespoon cooking oil (e.g., coconut oil, sesame oil, or vegetable oil) or ghee",
+        "1/2 teaspoon black mustard seeds (rai)",
+        "1/2 teaspoon urad dal (split black gram lentils, optional)",
+        "1-2 dried red chilies, broken into pieces (optional, for heat)",
+        "1 sprig (about 10-15) fresh curry leaves",
+        "A pinch of asafoetida (hing) (optional)"
+      ],
+      "steps": [
+        "Ensure all ingredients are prepped and within reach, as tempering is a quick process.",
+        "Heat the oil or ghee in a small pan (often a special tadka pan) over medium-high heat until it's hot but not smoking.",
+        "Add the black mustard seeds to the hot oil. Wait for them to splutter and pop, which usually takes a few seconds. Be cautious as they can jump out of the pan.",
+        "If using, add the urad dal and dried red chilies next. Fry for a few seconds, stirring, until the dal turns a light golden brown. Do not let it burn.",
+        "Carefully add the fresh curry leaves to the pan (they may spatter if there's any moisture on them). Add the asafoetida if using.",
+        "Stir and fry for another 5-10 seconds until the curry leaves become crisp and very aromatic.",
+        "Immediately pour the entire tempering mixture (the oil along with all the spices) over your prepared dish (e.g., dal, sambar, chutney, upma, poha, or a vegetable sabzi).",
+        "Often, the dish is then covered for a minute to allow the flavors to infuse before stirring it in or serving."
+      ]
+    }
+  ]
+}

--- a/src/lib/data/vegetables/ivy-gourd.json
+++ b/src/lib/data/vegetables/ivy-gourd.json
@@ -1,0 +1,140 @@
+{
+  "id": "ivy-gourd",
+  "commonName": "Ivy Gourd",
+  "scientificName": "Coccinia grandis",
+  "image": "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Ivy_gourd_in_India.JPG/800px-Ivy_gourd_in_India.JPG",
+  "description": "Ivy Gourd (Coccinia grandis), also known as scarlet gourd, tindora, or kovakkai, is a tropical vine that produces small, elongated green fruits which turn red when ripe. The young green fruits are commonly used as a vegetable in many Asian and African cuisines, valued for their crisp texture and mild, slightly tangy taste when cooked.",
+  "origin": "Native range extends from Africa to Asia, including India, Philippines, Cambodia, China, Indonesia, Malaysia, Myanmar, Thailand, Vietnam, and parts of Australia.",
+  "localNames": [
+    "Tindora / Kundru (Hindi)",
+    "Kovakkai (Tamil)",
+    "Tendli / Tondli (Marathi, Konkani)",
+    "Dondakaya (Telugu)",
+    "Kowai (Bengali)",
+    "Manoli (Tulu)"
+  ],
+  "regions": [
+    "India (widely cultivated and consumed)",
+    "Southeast Asia (Thailand, Indonesia, Malaysia, Philippines, Vietnam)",
+    "Africa (parts of)",
+    "Caribbean (introduced)",
+    "United States (Hawaii, Florida - introduced, sometimes considered invasive)"
+  ],
+  "seasons": [
+    "Available year-round in tropical climates where it grows perennially. Peak fruiting may coincide with rainy seasons or warmer months in different regions."
+  ],
+  "nutrition": {
+    "calories": "18 kcal per 100g (raw)",
+    "macronutrients": [
+      {
+        "name": "Protein",
+        "value": 1.2,
+        "unit": "g"
+      },
+      {
+        "name": "Carbohydrates",
+        "value": 3.1,
+        "unit": "g"
+      },
+      {
+        "name": "Fat",
+        "value": 0.1,
+        "unit": "g"
+      },
+      {
+        "name": "Fiber",
+        "value": 1.6,
+        "unit": "g"
+      }
+    ],
+    "vitamins": [
+      {
+        "name": "Vitamin C",
+        "value": 1.4,
+        "unit": "mg",
+        "rdi": "2%"
+      },
+      {
+        "name": "Vitamin B6",
+        "value": 0.075,
+        "unit": "mg",
+        "rdi": "4%"
+      },
+      {
+        "name": "Vitamin A",
+        "value": 3,
+        "unit": "µg RAE",
+        "rdi": "0%"
+      }
+    ],
+    "minerals": [
+      {
+        "name": "Calcium",
+        "value": 40,
+        "unit": "mg",
+        "rdi": "3%"
+      },
+      {
+        "name": "Iron",
+        "value": 0.4,
+        "unit": "mg",
+        "rdi": "2%"
+      },
+      {
+        "name": "Potassium",
+        "value": 30,
+        "unit": "mg",
+        "rdi": "1%"
+      }
+    ]
+  },
+  "healthBenefits": [
+    "Contains dietary fiber, which aids in digestion and can help maintain healthy blood sugar levels.",
+    "Provides some essential micronutrients, including Vitamin C and Calcium.",
+    "Traditionally used in some Ayurvedic and folk medicine practices for various ailments, including diabetes management (though more clinical research is needed)."
+  ],
+  "potentialAllergies": [
+    {
+      "name": "None widely reported",
+      "severity": "Very Low",
+      "details": "Ivy gourd is generally well-tolerated. Allergic reactions are very rare. As with any food, individual sensitivities can occur but are not common."
+    }
+  ],
+  "cultivationProcess": "Ivy gourd is a tropical perennial vine that climbs with tendrils. It's typically propagated by stem cuttings, which root easily. It thrives in warm, humid climates with well-drained soil and ample sunlight but can tolerate partial shade. The vine is a vigorous grower and requires support like a trellis or fence. Regular watering is beneficial, especially during dry periods. Fruits are harvested when young and green for vegetable purposes.",
+  "growthDuration": "Plants grown from cuttings can start producing fruit within 2-4 months. As a perennial vine, it can continue to produce fruit for several years with proper care. Young green fruits are harvested when they reach a suitable size, typically 2-3 inches long.",
+  "sustainabilityTips": [
+    "Ivy gourd is a prolific and hardy perennial vine that can be easily grown in home gardens in tropical and subtropical climates, providing a continuous supply of vegetables.",
+    "Its ability to grow on fences and trellises makes it suitable for vertical gardening, maximizing space in small gardens."
+  ],
+  "carbonFootprintInfo": "Locally grown ivy gourd, especially from home gardens or local farms, has a low carbon footprint due to minimal transportation and processing. Ivy gourd that is transported long distances to non-native regions will have a higher environmental impact.",
+  "staticRecipes": [
+    {
+      "name": "Simple Ivy Gourd Stir-Fry (Tindora Fry/Kovakkai Poriyal)",
+      "description": "A quick and easy South Indian style stir-fry showcasing the crisp texture of ivy gourd, lightly spiced and often garnished with coconut.",
+      "ingredients": [
+        "250g ivy gourd (tindora/kovakkai), washed and ends trimmed",
+        "1 tablespoon cooking oil (e.g., coconut oil or vegetable oil)",
+        "1/2 teaspoon black mustard seeds",
+        "1/2 teaspoon urad dal (split black gram lentils - optional)",
+        "1 dried red chili, broken into 1-2 pieces (adjust to heat preference)",
+        "1 sprig fresh curry leaves (about 10-12 leaves, optional but recommended)",
+        "1/4 teaspoon turmeric powder",
+        "Salt to taste",
+        "1-2 tablespoons grated fresh or desiccated coconut (optional, for garnish)"
+      ],
+      "steps": [
+        "Prepare the ivy gourd: Wash the ivy gourd thoroughly. Trim off both ends. Slice the ivy gourd thinly into rounds (about 2-3mm thick) or lengthwise into quarters.",
+        "Heat the oil in a medium-sized pan (kadai or skillet) over medium heat.",
+        "Once the oil is hot, add the mustard seeds. Wait for them to splutter completely.",
+        "If using, add the urad dal and the broken dried red chili. Fry for a few seconds until the urad dal turns light golden brown. Be careful not to burn the dal or chili.",
+        "Add the curry leaves (if using) to the hot oil – they will crisp up quickly and release their aroma.",
+        "Immediately add the sliced ivy gourd to the pan. Stir well to coat with the oil and spices.",
+        "Add the turmeric powder and salt to taste. Mix everything together thoroughly.",
+        "Cover the pan and cook on medium-low heat for about 5-7 minutes, stirring occasionally. The ivy gourd should become tender-crisp. If you prefer it softer, cook for a few more minutes.",
+        "Once the ivy gourd is cooked to your liking, uncover the pan and continue to cook for another 2-3 minutes, stirring, to allow any excess moisture to evaporate and to lightly roast the vegetable.",
+        "If using, stir in the grated fresh or desiccated coconut and mix well. Cook for another minute.",
+        "Serve the ivy gourd stir-fry hot as a side dish with rice and sambar/dal, or with roti/chapati."
+      ]
+    }
+  ]
+}

--- a/src/lib/data/vegetables/kale.json
+++ b/src/lib/data/vegetables/kale.json
@@ -1,0 +1,168 @@
+{
+  "id": "kale",
+  "commonName": "Kale",
+  "scientificName": "Brassica oleracea Acephala Group",
+  "image": "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b9/Boerenkool.jpg/800px-Boerenkool.jpg",
+  "description": "Kale is a nutrient-dense leafy green vegetable, a cultivar of Brassica oleracea. It is characterized by its green or purple leaves, which can be curly, smooth, or bumpy depending on the variety. Unlike cabbage, the central leaves do not form a compact head.",
+  "origin": "Eastern Mediterranean and Anatolia, cultivated since at least 2000 BCE.",
+  "localNames": [
+    "Boerenkool (Dutch - 'farmer's cabbage')",
+    "Grünkohl (German - 'green cabbage')",
+    "Chou frisé (French - 'curly cabbage')",
+    "Cavolo riccio (Italian - 'curly cabbage')",
+    "Leaf Cabbage (English)"
+  ],
+  "regions": [
+    "Europe (Germany, Netherlands, Scotland, Italy, Portugal)",
+    "North America (United States, Canada)",
+    "Asia (China, Japan)",
+    "Widely cultivated in many temperate and some subtropical regions globally."
+  ],
+  "seasons": [
+    "Primarily a cool-season crop, best harvested in Autumn, Winter, and early Spring. Some varieties are more heat tolerant, allowing for summer harvests in cooler areas. Frost can improve its flavor."
+  ],
+  "nutrition": {
+    "calories": "49 kcal per 100g (raw)",
+    "macronutrients": [
+      {
+        "name": "Protein",
+        "value": 4.28,
+        "unit": "g"
+      },
+      {
+        "name": "Carbohydrates",
+        "value": 8.75,
+        "unit": "g"
+      },
+      {
+        "name": "Fat",
+        "value": 0.93,
+        "unit": "g"
+      },
+      {
+        "name": "Fiber",
+        "value": 4.1,
+        "unit": "g"
+      }
+    ],
+    "vitamins": [
+      {
+        "name": "Vitamin K",
+        "value": 389.6,
+        "unit": "µg",
+        "rdi": "325%"
+      },
+      {
+        "name": "Vitamin A",
+        "value": 241,
+        "unit": "µg RAE",
+        "rdi": "27%"
+      },
+      {
+        "name": "Vitamin C",
+        "value": 120,
+        "unit": "mg",
+        "rdi": "133%"
+      },
+      {
+        "name": "Folate (B9)",
+        "value": 141,
+        "unit": "µg",
+        "rdi": "35%"
+      },
+      {
+        "name": "Vitamin B6",
+        "value": 0.271,
+        "unit": "mg",
+        "rdi": "16%"
+      }
+    ],
+    "minerals": [
+      {
+        "name": "Manganese",
+        "value": 0.659,
+        "unit": "mg",
+        "rdi": "29%"
+      },
+      {
+        "name": "Calcium",
+        "value": 254,
+        "unit": "mg",
+        "rdi": "19%"
+      },
+      {
+        "name": "Potassium",
+        "value": 491,
+        "unit": "mg",
+        "rdi": "10%"
+      },
+      {
+        "name": "Magnesium",
+        "value": 47,
+        "unit": "mg",
+        "rdi": "11%"
+      },
+      {
+        "name": "Iron",
+        "value": 1.47,
+        "unit": "mg",
+        "rdi": "8%"
+      },
+      {
+        "name": "Phosphorus",
+        "value": 92,
+        "unit": "mg",
+        "rdi": "7%"
+      }
+    ]
+  },
+  "healthBenefits": [
+    "Exceptionally rich in Vitamin K, crucial for blood clotting and bone health.",
+    "Excellent source of Vitamin A (from carotenoids like lutein and zeaxanthin) and Vitamin C, both powerful antioxidants that support immune function and protect against cellular damage.",
+    "High in dietary fiber and contains various beneficial phytochemicals, including glucosinolates, which have been studied for their health-promoting properties."
+  ],
+  "potentialAllergies": [
+    {
+      "name": "Goitrogens",
+      "severity": "Low (for most individuals)",
+      "details": "Contains goitrogens, which may interfere with thyroid function in individuals with pre-existing thyroid conditions, especially if consumed raw in very large quantities. Cooking typically reduces goitrogen levels."
+    },
+    {
+      "name": "Vitamin K interaction",
+      "severity": "Low to Moderate (for individuals on blood thinners)",
+      "details": "Due to its very high Vitamin K content, individuals taking blood-thinning medications (e.g., warfarin) should maintain a consistent intake of kale and consult their doctor to avoid interference with medication."
+    }
+  ],
+  "cultivationProcess": "Kale is a hardy biennial often grown as an annual. It thrives in cool weather and can tolerate frosts, which can enhance its sweetness. It prefers well-drained, fertile soil rich in organic matter and can grow in full sun to partial shade. Seeds can be sown directly in the garden or started indoors and transplanted. Kale requires consistent watering, especially during dry periods. Different varieties (curly, Lacinato/dinosaur, Red Russian) have slightly different growth habits.",
+  "growthDuration": "Typically 55-75 days from sowing to first harvest for baby leaves, and 70-95 days for mature leaves, depending on the variety and growing conditions. Many varieties allow for continuous harvesting of outer leaves.",
+  "sustainabilityTips": [
+    "Kale is a robust crop that can be grown in diverse climates, often with fewer inputs than more delicate greens, making it suitable for home gardening and local food systems.",
+    "Employ the 'cut-and-come-again' harvesting method by picking outer leaves first; this allows the plant to continue producing for an extended period, maximizing yield from a single plant."
+  ],
+  "carbonFootprintInfo": "Locally grown kale, particularly when in season and grown outdoors, has a relatively low carbon footprint. Kale that is transported long distances, grown in energy-intensive greenhouses, or heavily packaged (e.g., pre-washed and bagged) will have a higher environmental impact.",
+  "staticRecipes": [
+    {
+      "name": "Simple Sautéed Kale with Garlic",
+      "description": "A quick, easy, and nutritious way to prepare kale. Sautéing with garlic enhances its flavor while retaining many of its beneficial nutrients.",
+      "ingredients": [
+        "1 large bunch of kale (approx. 250-300g), tough stems removed, leaves washed and roughly chopped",
+        "1-2 tablespoons olive oil",
+        "2-3 cloves garlic, thinly sliced or minced",
+        "A pinch of red pepper flakes (optional)",
+        "Salt to taste",
+        "Freshly ground black pepper to taste",
+        "A squeeze of fresh lemon juice (optional, for finishing)"
+      ],
+      "steps": [
+        "Prepare the kale: Wash the kale leaves thoroughly under cold running water. Remove the tough central stems by either cutting them out with a knife or by holding the stem with one hand and pulling the leafy part off with the other. Roughly chop or tear the leaves into bite-sized pieces.",
+        "Heat the olive oil in a large skillet, pan, or Dutch oven over medium heat.",
+        "Add the sliced or minced garlic and the optional red pepper flakes to the skillet. Cook for about 30 seconds to 1 minute, stirring constantly, until the garlic is fragrant. Be careful not to let the garlic brown or burn, as this can make it taste bitter.",
+        "Add the chopped kale to the skillet. The pan might seem very full, but the kale will wilt down significantly as it cooks. If necessary, add the kale in batches, waiting for the first batch to wilt slightly before adding more.",
+        "Sauté the kale, stirring or tossing frequently with tongs or a spatula, for about 5 to 8 minutes. The kale should become tender and turn a vibrant green. If the pan becomes too dry, you can add a tablespoon or two of water or vegetable broth to help steam the kale and prevent sticking.",
+        "Season the sautéed kale with salt and freshly ground black pepper to your taste.",
+        "Once the kale is tender to your liking, remove the skillet from the heat. If desired, squeeze a bit of fresh lemon juice over the kale for a touch of brightness. Toss to combine.",
+        "Serve immediately as a healthy side dish."
+      ]
+    }
+  ]
+}

--- a/src/lib/data/vegetables/kohlrabi.json
+++ b/src/lib/data/vegetables/kohlrabi.json
@@ -1,0 +1,175 @@
+{
+  "id": "kohlrabi",
+  "commonName": "Kohlrabi",
+  "scientificName": "Brassica oleracea Gongylodes Group",
+  "image": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/d4/Brassica_oleracea_var._gongylodes_%28kohlrabi%29.jpg/800px-Brassica_oleracea_var._gongylodes_%28kohlrabi%29.jpg",
+  "description": "Kohlrabi, also known as German turnip, is a stout, biennial cultivar of wild cabbage. Its swollen, globe-shaped stem is the primary edible part, offering a taste and texture similar to a broccoli stem or cabbage heart but milder, sweeter, and often crisper. It can be eaten raw or cooked.",
+  "origin": "Europe (first recorded in Italy in the mid-16th century, spreading to Northern Europe thereafter).",
+  "localNames": [
+    "German Turnip (English)",
+    "Turnip Cabbage (English)",
+    "Kohlrübe (German - older term)",
+    "Cavolo Rapa (Italian)",
+    "Chou-rave (French)"
+  ],
+  "regions": [
+    "Europe (Germany, Austria, Switzerland, Italy, Poland, Netherlands)",
+    "North America (United States, Canada)",
+    "Asia (India - especially Kashmir, Vietnam, China)"
+  ],
+  "seasons": [
+    "Primarily a cool-season crop, with main harvests in Spring and Autumn in temperate climates. Some varieties are adapted for summer or overwintering in milder regions."
+  ],
+  "nutrition": {
+    "calories": "27 kcal per 100g (raw)",
+    "macronutrients": [
+      {
+        "name": "Protein",
+        "value": 1.7,
+        "unit": "g"
+      },
+      {
+        "name": "Carbohydrates",
+        "value": 6.2,
+        "unit": "g"
+      },
+      {
+        "name": "Fat",
+        "value": 0.1,
+        "unit": "g"
+      },
+      {
+        "name": "Fiber",
+        "value": 3.6,
+        "unit": "g"
+      }
+    ],
+    "vitamins": [
+      {
+        "name": "Vitamin C",
+        "value": 62,
+        "unit": "mg",
+        "rdi": "69%"
+      },
+      {
+        "name": "Vitamin B6",
+        "value": 0.15,
+        "unit": "mg",
+        "rdi": "9%"
+      },
+      {
+        "name": "Folate (B9)",
+        "value": 16,
+        "unit": "µg",
+        "rdi": "4%"
+      },
+      {
+        "name": "Thiamin (B1)",
+        "value": 0.05,
+        "unit": "mg",
+        "rdi": "4%"
+      },
+      {
+        "name": "Riboflavin (B2)",
+        "value": 0.02,
+        "unit": "mg",
+        "rdi": "2%"
+      },
+      {
+        "name": "Vitamin K",
+        "value": 0.1,
+        "unit": "µg",
+        "rdi": "0%"
+      }
+    ],
+    "minerals": [
+      {
+        "name": "Potassium",
+        "value": 350,
+        "unit": "mg",
+        "rdi": "7%"
+      },
+      {
+        "name": "Manganese",
+        "value": 0.139,
+        "unit": "mg",
+        "rdi": "6%"
+      },
+      {
+        "name": "Copper",
+        "value": 0.129,
+        "unit": "mg",
+        "rdi": "14%"
+      },
+      {
+        "name": "Phosphorus",
+        "value": 46,
+        "unit": "mg",
+        "rdi": "4%"
+      },
+      {
+        "name": "Magnesium",
+        "value": 19,
+        "unit": "mg",
+        "rdi": "5%"
+      },
+      {
+        "name": "Calcium",
+        "value": 24,
+        "unit": "mg",
+        "rdi": "2%"
+      },
+      {
+        "name": "Iron",
+        "value": 0.4,
+        "unit": "mg",
+        "rdi": "2%"
+      }
+    ]
+  },
+  "healthBenefits": [
+    "Excellent source of Vitamin C, a powerful antioxidant that boosts the immune system and supports collagen synthesis.",
+    "Good source of dietary fiber, promoting digestive health, regularity, and satiety.",
+    "Contains glucosinolates and other phytonutrients common to Brassica vegetables, which are studied for their potential anti-cancer properties."
+  ],
+  "potentialAllergies": [
+    {
+      "name": "Goitrogens",
+      "severity": "Low (for most individuals)",
+      "details": "Like other Brassica vegetables, kohlrabi contains goitrogens, compounds that may interfere with thyroid function in individuals with pre-existing thyroid conditions, particularly if consumed raw in very large amounts. Cooking typically reduces these compounds."
+    }
+  ],
+  "cultivationProcess": "Kohlrabi is a cool-season biennial typically grown as an annual. It's cultivated for its swollen, bulb-like stem that grows above ground. It prefers well-drained soil rich in organic matter and consistent moisture. Seeds can be sown directly in early spring for a summer crop or in mid-to-late summer for an autumn or winter crop. Plants should be thinned to allow bulbs to develop properly. Both green and purple varieties exist.",
+  "growthDuration": "Kohlrabi matures relatively quickly, typically within 55-60 days after sowing, depending on the variety and growing conditions. It should be harvested when the stem is about 5-8 cm (2-3 inches) in diameter for best texture and flavor.",
+  "sustainabilityTips": [
+    "Kohlrabi is a fast-growing crop that can be easily incorporated into home gardens and crop rotation plans.",
+    "Both the swollen stem and the leaves of kohlrabi are edible, allowing for full use of the harvested plant and reducing food waste."
+  ],
+  "carbonFootprintInfo": "Locally grown kohlrabi, especially when in season, has a low carbon footprint. As with most vegetables, kohlrabi transported long distances or grown out of season using energy-intensive methods (like heated greenhouses) will have a higher environmental impact.",
+  "staticRecipes": [
+    {
+      "name": "Crisp Kohlrabi Slaw",
+      "description": "A refreshing and crunchy slaw made with raw kohlrabi, offering a mild, slightly sweet, and peppery flavor. A great alternative to traditional cabbage slaw.",
+      "ingredients": [
+        "1 medium kohlrabi (about 300-400g), peeled and trimmed",
+        "1 large carrot, peeled (optional)",
+        "1/4 cup mayonnaise (or Greek yogurt for a lighter dressing)",
+        "2 tablespoons apple cider vinegar",
+        "1 teaspoon Dijon mustard",
+        "1/2 teaspoon sugar or honey (optional, or to taste)",
+        "Salt to taste",
+        "Freshly ground black pepper to taste",
+        "1-2 tablespoons fresh parsley or chives, finely chopped (for garnish)"
+      ],
+      "steps": [
+        "Prepare the kohlrabi: Peel the tough outer skin from the kohlrabi bulb using a sharp vegetable peeler or knife. Also, trim off the woody base.",
+        "Grate or julienne the kohlrabi: You can either grate the kohlrabi using the large holes of a box grater or cut it into thin matchsticks (julienne). If using a carrot, grate or julienne it as well. Place the prepared kohlrabi (and carrot) in a medium-sized bowl.",
+        "Make the dressing: In a separate small bowl, whisk together the mayonnaise (or Greek yogurt), apple cider vinegar, Dijon mustard, and optional sugar or honey until smooth.",
+        "Season the dressing with salt and freshly ground black pepper to your liking.",
+        "Combine the slaw: Pour the dressing over the kohlrabi mixture. Toss everything together until the kohlrabi is evenly coated with the dressing.",
+        "Chill (recommended): For the best flavor, cover the bowl and refrigerate the kohlrabi slaw for at least 15-30 minutes before serving. This allows the flavors to meld together.",
+        "Serve: Just before serving, give the slaw a final toss. Garnish with fresh chopped parsley or chives if desired. This slaw is excellent as a side dish with grilled meats, sandwiches, or burgers."
+      ]
+    }
+  ]
+}

--- a/src/lib/data/vegetables/lettuce.json
+++ b/src/lib/data/vegetables/lettuce.json
@@ -1,0 +1,165 @@
+{
+  "id": "lettuce",
+  "commonName": "Lettuce",
+  "scientificName": "Lactuca sativa",
+  "image": "https://upload.wikimedia.org/wikipedia/commons/thumb/9/91/Iceberg_lettuce_in_SB.jpg/800px-Iceberg_lettuce_in_SB.jpg",
+  "description": "Lettuce (Lactuca sativa) is an annual plant of the daisy family, Asteraceae, primarily grown as a leaf vegetable. It is most often used raw in salads, sandwiches, and wraps, but can also be cooked in soups or grilled. Varieties range from crisp iceberg heads to tender butterheads and colorful loose-leaf types.",
+  "origin": "Ancient Egypt (first cultivated by Egyptians, who developed it from a wild plant used for oilseed into a leaf crop).",
+  "localNames": [
+    "Laitue (French)",
+    "Lechuga (Spanish)",
+    "Kopfsalat (German - for head lettuce types)",
+    "Salata (Hindi, and many other languages for salad/lettuce)"
+  ],
+  "regions": [
+    "Worldwide",
+    "China (largest producer)",
+    "United States (California, Arizona)",
+    "India",
+    "Spain",
+    "Italy"
+  ],
+  "seasons": [
+    "Available year-round due to global cultivation, greenhouse production, and varied regional climates. Peak season for outdoor cultivation in temperate zones is spring and autumn."
+  ],
+  "nutrition": {
+    "calories": "14 kcal per 100g (Iceberg, raw)",
+    "macronutrients": [
+      {
+        "name": "Protein",
+        "value": 0.9,
+        "unit": "g"
+      },
+      {
+        "name": "Carbohydrates",
+        "value": 2.97,
+        "unit": "g"
+      },
+      {
+        "name": "Fat",
+        "value": 0.14,
+        "unit": "g"
+      },
+      {
+        "name": "Fiber",
+        "value": 1.2,
+        "unit": "g"
+      }
+    ],
+    "vitamins": [
+      {
+        "name": "Vitamin K",
+        "value": 24.1,
+        "unit": "µg",
+        "rdi": "20%"
+      },
+      {
+        "name": "Vitamin A",
+        "value": 25,
+        "unit": "µg RAE",
+        "rdi": "3%"
+      },
+      {
+        "name": "Folate (B9)",
+        "value": 29,
+        "unit": "µg",
+        "rdi": "7%"
+      },
+      {
+        "name": "Vitamin C",
+        "value": 2.8,
+        "unit": "mg",
+        "rdi": "3%"
+      },
+      {
+        "name": "Vitamin B6",
+        "value": 0.042,
+        "unit": "mg",
+        "rdi": "2%"
+      }
+    ],
+    "minerals": [
+      {
+        "name": "Potassium",
+        "value": 141,
+        "unit": "mg",
+        "rdi": "3%"
+      },
+      {
+        "name": "Iron",
+        "value": 0.41,
+        "unit": "mg",
+        "rdi": "2%"
+      },
+      {
+        "name": "Calcium",
+        "value": 18,
+        "unit": "mg",
+        "rdi": "1%"
+      },
+      {
+        "name": "Magnesium",
+        "value": 7,
+        "unit": "mg",
+        "rdi": "2%"
+      },
+      {
+        "name": "Phosphorus",
+        "value": 20,
+        "unit": "mg",
+        "rdi": "2%"
+      }
+    ]
+  },
+  "healthBenefits": [
+    "High water content (about 95-96%) makes it hydrating and low in calories.",
+    "Good source of Vitamin K, crucial for blood clotting and bone health.",
+    "Darker green varieties are a good source of Vitamin A (as beta-carotene), important for vision and immune function."
+  ],
+  "potentialAllergies": [
+    {
+      "name": "Lettuce Allergy (rare)",
+      "severity": "Mild to Moderate",
+      "details": "True lettuce allergy is uncommon but can cause symptoms like itching, hives, or digestive upset. Oral Allergy Syndrome may occur in individuals with pollen allergies (e.g., ragweed, mugwort)."
+    },
+    {
+      "name": "Foodborne Illness Risk",
+      "severity": "Varies",
+      "details": "Like other raw vegetables, lettuce can be a source of foodborne illnesses if contaminated (e.g., E. coli, Salmonella). Thorough washing is recommended."
+    }
+  ],
+  "cultivationProcess": "Lettuce is a cool-season annual crop. It grows best in full sun in loose, nitrogen-rich, well-drained soils with a pH of 6.0-6.8. Seeds can be sown directly or started indoors and transplanted. Consistent moisture is important. High temperatures can cause bolting (premature flowering and bitterness). Different types (leaf, romaine, iceberg, butterhead) have varied growth habits.",
+  "growthDuration": "Generally 45-80 days from sowing to harvest for leaf lettuce, and 65-130 days for head lettuce varieties, depending on the type and growing conditions.",
+  "sustainabilityTips": [
+    "Grow lettuce at home in gardens or containers; it's relatively easy and reduces packaging and transportation.",
+    "Store lettuce properly (e.g., wrapped loosely in a damp paper towel in the refrigerator's crisper drawer) to maximize freshness and minimize food waste."
+  ],
+  "carbonFootprintInfo": "Locally grown, field-harvested lettuce consumed in season has a relatively low carbon footprint. However, lettuce grown in heated greenhouses, or transported long distances under refrigeration (especially pre-packaged salads), has a significantly higher environmental impact.",
+  "staticRecipes": [
+    {
+      "name": "Simple Green Salad with Vinaigrette",
+      "description": "A classic and versatile green salad featuring crisp lettuce and a tangy homemade vinaigrette dressing. Easily customizable with other fresh vegetables.",
+      "ingredients": [
+        "1 medium head of lettuce (e.g., Romaine, Green Leaf, or Butter lettuce), washed and torn",
+        "1/2 cucumber, thinly sliced (optional)",
+        "1 cup cherry tomatoes, halved (optional)",
+        "1/4 red onion, thinly sliced (optional)",
+        "For the Vinaigrette:",
+        "3 tablespoons extra virgin olive oil",
+        "1 tablespoon red wine vinegar (or apple cider vinegar/lemon juice)",
+        "1 teaspoon Dijon mustard",
+        "1/2 teaspoon honey or maple syrup (optional, for balance)",
+        "Salt and freshly ground black pepper to taste"
+      ],
+      "steps": [
+        "Prepare the lettuce and vegetables: Wash all lettuce leaves thoroughly and dry them completely using a salad spinner or by patting gently with clean kitchen towels. Tear or chop the lettuce into bite-sized pieces and place them in a large salad bowl.",
+        "If using, add the sliced cucumber, halved cherry tomatoes, and thinly sliced red onion to the bowl with the lettuce.",
+        "Make the vinaigrette: In a small bowl or a jar with a tight-fitting lid, combine the extra virgin olive oil, red wine vinegar, Dijon mustard, and optional honey or maple syrup.",
+        "Season the vinaigrette with salt and freshly ground black pepper according to your preference.",
+        "Whisk vigorously or shake the jar until the dressing is well combined and slightly emulsified.",
+        "Dress the salad: Just before serving, pour about half of the vinaigrette over the salad greens. Toss gently to coat all the leaves lightly. Add more dressing as needed to your liking, being careful not to overdress and make the salad soggy.",
+        "Serve immediately as a fresh side dish or as a base for a more substantial salad with added protein."
+      ]
+    }
+  ]
+}

--- a/src/lib/data/vegetables/lotus-stem.json
+++ b/src/lib/data/vegetables/lotus-stem.json
@@ -1,0 +1,169 @@
+{
+  "id": "lotus-stem",
+  "commonName": "Lotus Stem / Root",
+  "scientificName": "Nelumbo nucifera",
+  "image": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/31/Lotus_root.jpg/800px-Lotus_root.jpg",
+  "description": "Lotus stem, commonly known as lotus root, is the edible rhizome (underwater stem) of the lotus plant. When sliced, it reveals a distinctive lace-like pattern of air channels. It has a crisp, crunchy texture and a mild, slightly sweet, and starchy flavor. It is a popular ingredient in many Asian cuisines and can be stir-fried, braised, boiled in soups, or pickled.",
+  "origin": "Native to a wide region across Asia (from India through Southeast Asia to East Asia) and parts of northern and eastern Australia.",
+  "localNames": [
+    "Kamal Kakdi (Hindi)",
+    "Renkon (蓮根 - Japanese)",
+    "Yeon-geun (연근 - Korean)",
+    "Lián-ǒu (蓮藕 - Chinese)",
+    "Bhasin / Bhein (Punjabi)",
+    "Nadru (Kashmiri)"
+  ],
+  "regions": [
+    "China (major producer)",
+    "Japan",
+    "India",
+    "South Korea",
+    "Vietnam",
+    "Thailand",
+    "Indonesia",
+    "Sri Lanka",
+    "Australia (northern regions)"
+  ],
+  "seasons": [
+    "Typically harvested from late summer through winter (July to March in some regions), though availability can extend year-round in many Asian markets due to varied cultivation and storage."
+  ],
+  "nutrition": {
+    "calories": "66 kcal per 100g (cooked, boiled, drained)",
+    "macronutrients": [
+      {
+        "name": "Protein",
+        "value": 1.58,
+        "unit": "g"
+      },
+      {
+        "name": "Carbohydrates",
+        "value": 16.02,
+        "unit": "g"
+      },
+      {
+        "name": "Fat",
+        "value": 0.07,
+        "unit": "g"
+      },
+      {
+        "name": "Fiber",
+        "value": 3.1,
+        "unit": "g"
+      }
+    ],
+    "vitamins": [
+      {
+        "name": "Vitamin C",
+        "value": 27.4,
+        "unit": "mg",
+        "rdi": "30%"
+      },
+      {
+        "name": "Vitamin B6",
+        "value": 0.218,
+        "unit": "mg",
+        "rdi": "13%"
+      },
+      {
+        "name": "Thiamin (B1)",
+        "value": 0.127,
+        "unit": "mg",
+        "rdi": "11%"
+      },
+      {
+        "name": "Folate (B9)",
+        "value": 8,
+        "unit": "µg",
+        "rdi": "2%"
+      },
+      {
+        "name": "Vitamin K",
+        "value": 0.4,
+        "unit": "µg",
+        "rdi": "0%"
+      }
+    ],
+    "minerals": [
+      {
+        "name": "Copper",
+        "value": 0.221,
+        "unit": "mg",
+        "rdi": "25%"
+      },
+      {
+        "name": "Potassium",
+        "value": 363,
+        "unit": "mg",
+        "rdi": "8%"
+      },
+      {
+        "name": "Phosphorus",
+        "value": 78,
+        "unit": "mg",
+        "rdi": "6%"
+      },
+      {
+        "name": "Manganese",
+        "value": 0.22,
+        "unit": "mg",
+        "rdi": "10%"
+      },
+      {
+        "name": "Iron",
+        "value": 0.9,
+        "unit": "mg",
+        "rdi": "5%"
+      }
+    ]
+  },
+  "healthBenefits": [
+    "Good source of dietary fiber, which aids digestion, promotes gut health, and can help manage blood sugar levels.",
+    "Rich in Vitamin C, an antioxidant that boosts the immune system and supports collagen production.",
+    "Contains essential minerals like potassium for heart health, copper for enzyme function, and phosphorus for bone health."
+  ],
+  "potentialAllergies": [
+    {
+      "name": "Parasite risk (if raw)",
+      "severity": "Moderate to High",
+      "details": "Raw lotus root may carry parasites like Fasciolopsis buski. It is strongly recommended to cook lotus root thoroughly before consumption to eliminate this risk."
+    }
+  ],
+  "cultivationProcess": "Lotus (Nelumbo nucifera) is an aquatic perennial plant. The rhizomes (lotus stems/roots) are planted in the mud of shallow ponds, lakes, or flooded fields. The plant requires warm temperatures and full sun. Leaves and flowers float on or rise above the water surface. Rhizomes spread horizontally in the mud and are harvested when they reach a suitable size, typically after the water is drained from the field or pond.",
+  "growthDuration": "Lotus rhizomes typically mature and are ready for harvest approximately 6 to 9 months after planting the initial propagule (a piece of rhizome with a bud).",
+  "sustainabilityTips": [
+    "Lotus plants are used in phytoremediation to help clean polluted water bodies, as they can absorb heavy metals and excess nutrients.",
+    "All parts of the lotus plant (roots, stems, leaves, flowers, seeds) are edible or have traditional uses, making it a very low-waste crop."
+  ],
+  "carbonFootprintInfo": "Locally grown lotus stem, especially when cultivated in traditional aquatic farming systems that mimic its natural habitat, generally has a moderate carbon footprint. Transporting fresh or processed lotus stem over long distances, particularly if requiring refrigeration, increases its environmental impact.",
+  "staticRecipes": [
+    {
+      "name": "Simple Stir-fried Lotus Root with Ginger and Soy",
+      "description": "A quick and flavorful stir-fry that showcases the uniquely crisp and crunchy texture of lotus root, enhanced with the aromatic flavors of ginger and soy sauce.",
+      "ingredients": [
+        "1 large lotus root (about 250-300g)",
+        "1 tablespoon vegetable oil or peanut oil",
+        "1-2 cloves garlic, minced",
+        "1 teaspoon fresh ginger, minced",
+        "1 tablespoon light soy sauce",
+        "1 teaspoon rice vinegar (or white vinegar)",
+        "1/2 teaspoon granulated sugar (optional)",
+        "A few drops of sesame oil (optional)",
+        "1 spring onion, thinly sliced (for garnish, optional)",
+        "A splash of water (if needed during stir-frying)"
+      ],
+      "steps": [
+        "Prepare the lotus root: Peel the tough outer skin of the lotus root using a vegetable peeler. Slice it crosswise into thin rounds (about 1/8 inch or 3mm thick). As you slice, immediately place the rounds into a bowl of cold water mixed with a teaspoon of vinegar or lemon juice to prevent them from browning due to oxidation.",
+        "Rinse the sliced lotus root under fresh cold water to remove any excess starch. Drain thoroughly.",
+        "Heat the cooking oil in a wok or large skillet over medium-high heat until the oil is hot and shimmering.",
+        "Add the minced garlic and minced ginger to the hot oil. Stir-fry for about 20-30 seconds until fragrant. Be careful not to burn them.",
+        "Add the drained lotus root slices to the wok. Stir-fry continuously for 3-5 minutes. The lotus root should become slightly translucent around the edges but remain crisp.",
+        "In a small bowl, mix together the light soy sauce, rice vinegar, and optional sugar until the sugar (if using) is dissolved.",
+        "Pour the sauce mixture over the lotus root in the wok. Stir well to ensure all the slices are evenly coated with the sauce.",
+        "Continue to stir-fry for another 1-2 minutes, or until the sauce has slightly thickened and glazed the lotus root slices. If the wok becomes too dry, add a small splash of water to prevent sticking.",
+        "If using, drizzle with a few drops of sesame oil and give it a final quick toss.",
+        "Remove from heat and transfer to a serving dish. Garnish with thinly sliced spring onions or fresh coriander if desired.",
+        "Serve immediately as a side dish or as part of a multi-course Asian meal. Enjoy the crunchy texture!"
+      ]
+    }
+  ]
+}

--- a/src/lib/data/vegetables/spring-onion.json
+++ b/src/lib/data/vegetables/spring-onion.json
@@ -1,0 +1,138 @@
+{
+  "id": "spring-onion",
+  "commonName": "Spring Onion",
+  "scientificName": "Allium spp. (commonly Allium cepa or Allium fistulosum)",
+  "image": "https://upload.wikimedia.org/wikipedia/commons/thumb/1/1c/CSA-Red-Spring-Onions.jpg/800px-CSA-Red-Spring-Onions.jpg",
+  "description": "Spring onions, also known as scallions or green onions, are young onions harvested before the bulb has fully developed. They feature long, hollow green stalks and a small white base, both of which are edible and offer a milder, fresher onion flavor than mature onions. They are widely used raw as a garnish or cooked in various dishes.",
+  "origin": "Various Allium species native to Asia; modern cultivated forms developed globally. The term 'scallion' historically refers to onions from Ashkelon (ancient Palestine).",
+  "localNames": [
+    "Scallion (USA)",
+    "Green Onion (USA, Canada)",
+    "Salad Onion (UK)",
+    "Cebollita / Cebolla de Verdeo (Spanish)",
+    "Oignon vert / Ciboule (French)"
+  ],
+  "regions": [
+    "Worldwide",
+    "China (major producer of Allium species)",
+    "Mexico",
+    "United States",
+    "Japan",
+    "South Korea",
+    "Many parts of Europe and Asia"
+  ],
+  "seasons": [
+    "Available year-round due to varied cultivation methods (field and greenhouse) and global sourcing. Peak season for outdoor cultivation in temperate climates is typically spring and summer."
+  ],
+  "nutrition": {
+    "calories": "32 kcal per 100g (raw, tops and bulb)",
+    "macronutrients": [
+      {
+        "name": "Protein",
+        "value": 1.83,
+        "unit": "g"
+      },
+      {
+        "name": "Carbohydrates",
+        "value": 7.34,
+        "unit": "g"
+      },
+      {
+        "name": "Fat",
+        "value": 0.19,
+        "unit": "g"
+      },
+      {
+        "name": "Fiber",
+        "value": 2.6,
+        "unit": "g"
+      }
+    ],
+    "vitamins": [
+      {
+        "name": "Vitamin K",
+        "value": 207,
+        "unit": "µg",
+        "rdi": "173%"
+      },
+      {
+        "name": "Vitamin C",
+        "value": 18.8,
+        "unit": "mg",
+        "rdi": "21%"
+      },
+      {
+        "name": "Folate (B9)",
+        "value": 64,
+        "unit": "µg",
+        "rdi": "16%"
+      },
+      {
+        "name": "Vitamin A",
+        "value": 50,
+        "unit": "µg RAE",
+        "rdi": "6%"
+      }
+    ],
+    "minerals": [
+      {
+        "name": "Potassium",
+        "value": 276,
+        "unit": "mg",
+        "rdi": "6%"
+      },
+      {
+        "name": "Calcium",
+        "value": 72,
+        "unit": "mg",
+        "rdi": "6%"
+      },
+      {
+        "name": "Iron",
+        "value": 1.48,
+        "unit": "mg",
+        "rdi": "8%"
+      }
+    ]
+  },
+  "healthBenefits": [
+    "Excellent source of Vitamin K, vital for blood clotting and bone health.",
+    "Good source of Vitamin C, an antioxidant that supports the immune system and collagen production.",
+    "Contains dietary fiber and various phytonutrients (like flavonoids and sulfur compounds common in Alliums) which may contribute to heart health and have anti-inflammatory properties."
+  ],
+  "potentialAllergies": [
+    {
+      "name": "Allium Allergy (rare)",
+      "severity": "Mild to Moderate",
+      "details": "Individuals allergic to other Allium species (like garlic, onions, leeks) may experience cross-reactivity. Symptoms can include skin irritation, digestive upset, or (rarely) more severe reactions."
+    }
+  ],
+  "cultivationProcess": "Spring onions are grown from seeds or sets (small bulbs). They prefer well-drained soil with plenty of organic matter and full sun. They are planted closely together as they don't form large bulbs. Regular watering is needed. They are harvested when the stalks are green and tender, typically before the bulb (if an A. cepa variety) significantly swells. Allium fistulosum varieties (Welsh onions) do not form bulbs and are always harvested for their stalks.",
+  "growthDuration": "Typically 60-90 days from seed to harvest, though some can be harvested earlier as microgreens (20-30 days) or later depending on desired size. They can often be harvested progressively.",
+  "sustainabilityTips": [
+    "Spring onions are easy to regrow from their root ends. Place the white root base (about an inch) in a shallow glass of water, and green shoots will resprout. Change water regularly and transplant to soil for continued growth.",
+    "Grow spring onions in home gardens or pots; they require little space and are relatively low-maintenance, providing fresh greens and reducing food miles."
+  ],
+  "carbonFootprintInfo": "Locally grown spring onions, especially when in season or from home gardens, have a very low carbon footprint. Those transported long distances, particularly if requiring refrigeration or air freight, will have a higher environmental impact.",
+  "staticRecipes": [
+    {
+      "name": "Spring Onion Garnish & Stir-fry Base",
+      "description": "Spring onions are a versatile ingredient, widely used as a fresh, pungent garnish or as an aromatic base in stir-fries and many other cooked dishes worldwide.",
+      "ingredients": [
+        "1 bunch of fresh spring onions (scallions)"
+      ],
+      "steps": [
+        "For Garnish:",
+        "1. Rinse the spring onions thoroughly under cold water.",
+        "2. Trim off the root ends (usually the bottom 1/4 inch). Remove any wilted or damaged outer layers or tips of the green tops.",
+        "3. Thinly slice the green tops crosswise into small rings or diagonally for a more decorative cut. The white and light green parts can also be thinly sliced and used as a garnish, offering a slightly stronger flavor.",
+        "4. Sprinkle the sliced spring onions over dishes like soups (e.g., ramen, pho, miso soup), salads, omelets, noodle dishes, rice bowls, tacos, baked potatoes, or savory pancakes just before serving. This adds a fresh, mild oniony crunch and visual appeal.",
+        "For Stir-fry Base / Cooking:",
+        "1. Wash and prepare the spring onions as described above (trimming roots and any wilted parts).",
+        "2. Separate the white and light green lower parts from the darker green tops. These parts have different textures and cooking times.",
+        "3. Slice the white and light green parts into 1-2 inch lengths, or chop them finely. These are typically added early in stir-frying along with other aromatics like garlic and ginger to build a flavor base.",
+        "4. Slice the dark green tops similarly (rings or longer sections). These are often added towards the very end of the stir-fry cooking process to preserve their delicate flavor and bright color, or they can be mixed in raw after cooking."
+      ]
+    }
+  ]
+}

--- a/src/lib/data/vegetables/young-jackfruit.json
+++ b/src/lib/data/vegetables/young-jackfruit.json
@@ -1,0 +1,132 @@
+{
+  "id": "young-jackfruit",
+  "commonName": "Young Jackfruit",
+  "scientificName": "Artocarpus heterophyllus",
+  "image": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0c/Unripe_jackfruit_cut_open.jpg/800px-Unripe_jackfruit_cut_open.jpg",
+  "description": "Young, unripe jackfruit has a neutral flavor and a distinctive, shreddable, meat-like texture, making it a popular ingredient in vegetarian and vegan dishes. It is widely used as a vegetable in South and Southeast Asian cuisines for curries, stews, and as a plant-based meat substitute.",
+  "origin": "Likely domesticated in the Indian subcontinent and Southeast Asia.",
+  "localNames": [
+    "Kathal (Hindi - unripe/young)",
+    "Polos (Sinhalese - young/green jackfruit)",
+    "Nangka Muda (Malay/Indonesian - young jackfruit)",
+    "Gulay na Langka (Tagalog - jackfruit vegetable)"
+  ],
+  "regions": [
+    "India",
+    "Bangladesh",
+    "Sri Lanka",
+    "Thailand",
+    "Indonesia",
+    "Malaysia",
+    "Philippines",
+    "Vietnam",
+    "Brazil",
+    "Caribbean Islands"
+  ],
+  "seasons": [
+    "Available year-round in many tropical regions, as the fruit is harvested at an immature stage for vegetable use."
+  ],
+  "nutrition": {
+    "calories": "28 kcal per 100g",
+    "macronutrients": [
+      {
+        "name": "Protein",
+        "value": 1.2,
+        "unit": "g"
+      },
+      {
+        "name": "Carbohydrates",
+        "value": 3.2,
+        "unit": "g"
+      },
+      {
+        "name": "Fat",
+        "value": 0.3,
+        "unit": "g"
+      },
+      {
+        "name": "Fiber",
+        "value": 3.0,
+        "unit": "g"
+      }
+    ],
+    "vitamins": [
+      {
+        "name": "Vitamin C",
+        "value": 7,
+        "unit": "mg",
+        "rdi": "8%"
+      },
+      {
+        "name": "Vitamin B6",
+        "value": 0.07,
+        "unit": "mg",
+        "rdi": "4%"
+      }
+    ],
+    "minerals": [
+      {
+        "name": "Potassium",
+        "value": 250,
+        "unit": "mg",
+        "rdi": "5%"
+      },
+      {
+        "name": "Manganese",
+        "value": 0.04,
+        "unit": "mg",
+        "rdi": "2%"
+      }
+    ]
+  },
+  "healthBenefits": [
+    "Good source of dietary fiber, which supports digestive health and can help manage blood sugar levels.",
+    "Low in calories and fat, making it a healthy addition to various dishes, especially as a meat substitute.",
+    "Provides some essential vitamins and minerals, contributing to overall nutrient intake."
+  ],
+  "potentialAllergies": [
+    {
+      "name": "Latex Sensitivity",
+      "severity": "Mild",
+      "details": "Raw jackfruit, including the young stage, contains a sticky latex. While this is usually reduced or eliminated by cooking, individuals with severe latex allergies might need to be cautious during preparation. Cooked young jackfruit is generally well-tolerated."
+    }
+  ],
+  "cultivationProcess": "Jackfruit trees (Artocarpus heterophyllus) are large, evergreen trees suited to tropical lowlands. They are propagated by seeds or vegetatively (grafting, budding). Trees require ample space, sunlight, and well-drained soil. They are relatively hardy and can start producing fruit for vegetable use (unripe stage) within a few years of planting, earlier than for ripe fruit production.",
+  "growthDuration": "Jackfruit trees typically start bearing fruit within 3-8 years, depending on propagation method (seedlings take longer). Unripe fruits for vegetable use are harvested while still young and firm, well before they reach full maturity and ripeness.",
+  "sustainabilityTips": [
+    "Young jackfruit is a versatile plant-based meat alternative; choosing it can help reduce meat consumption, which often has a higher environmental footprint.",
+    "Jackfruit trees are often grown in home gardens and mixed agroforestry systems, supporting local food systems and biodiversity."
+  ],
+  "carbonFootprintInfo": "Locally sourced young jackfruit, especially fresh, has a relatively low carbon footprint. Canned or processed young jackfruit, particularly if imported from distant regions, will have a higher footprint due to processing, packaging, and transportation.",
+  "staticRecipes": [
+    {
+      "name": "BBQ Pulled Jackfruit (Vegan Pulled Pork)",
+      "description": "Young, unripe jackfruit cooked until tender and easily shreddable, then simmered in barbecue sauce to create a popular and convincing vegan alternative to pulled pork. Ideal for sandwiches and tacos.",
+      "ingredients": [
+        "2 cans (each approx. 20 oz or 560g) young green jackfruit in brine or water, drained and rinsed",
+        "1 tablespoon olive oil or neutral cooking oil",
+        "1 medium onion, finely chopped",
+        "2-3 cloves garlic, minced",
+        "1 cup of your favorite barbecue sauce",
+        "1/4 to 1/2 cup vegetable broth or water",
+        "1 teaspoon smoked paprika",
+        "1/2 teaspoon ground cumin",
+        "1/4 teaspoon black pepper (or to taste)",
+        "Salt to taste (be mindful if jackfruit was in brine)",
+        "Burger buns, rolls, or tortillas for serving"
+      ],
+      "steps": [
+        "Prepare the jackfruit: Drain the canned jackfruit very well and rinse it under cold water. Remove any tough core sections and any visible seeds (young seeds are often soft and edible). Place the jackfruit pieces in a bowl and use two forks or your hands to shred them into a texture resembling pulled meat.",
+        "Sauté aromatics: Heat the olive oil in a large skillet or Dutch oven over medium heat. Add the chopped onion and cook until softened and translucent, about 3-5 minutes.",
+        "Add minced garlic and cook for another minute until fragrant, being careful not to burn it.",
+        "Cook jackfruit: Add the shredded jackfruit to the skillet. Cook for 5-7 minutes, stirring occasionally, allowing some pieces to get slightly browned and a bit crispy. This helps develop texture.",
+        "Add spices: Stir in the smoked paprika and ground cumin, cooking for another minute to toast the spices.",
+        "Simmer with sauce: Pour in the barbecue sauce and 1/4 cup of vegetable broth (or water). Stir everything well to ensure the jackfruit is fully coated.",
+        "Bring the mixture to a gentle simmer. Reduce the heat to low, cover the skillet, and let it cook for at least 20-30 minutes. For an even more tender result, you can simmer for up to 1 hour. Stir occasionally and add more broth/water if the mixture becomes too dry.",
+        "Finish and serve: Uncover the skillet and continue to cook for another 5-10 minutes, allowing any excess liquid to evaporate and the sauce to thicken and lightly caramelize on the jackfruit.",
+        "Taste and adjust seasoning with salt and black pepper if needed. Be cautious with salt if your jackfruit was canned in brine.",
+        "Serve the BBQ pulled jackfruit warm on burger buns, rolls, or in tacos, often accompanied by coleslaw or pickles."
+      ]
+    }
+  ]
+}

--- a/src/lib/data/vegetables/zucchini.json
+++ b/src/lib/data/vegetables/zucchini.json
@@ -1,0 +1,149 @@
+{
+  "id": "zucchini",
+  "commonName": "Zucchini",
+  "scientificName": "Cucurbita pepo",
+  "image": "https://upload.wikimedia.org/wikipedia/commons/thumb/9/93/Zucchini_fruits.jpg/1024px-Zucchini_fruits.jpg",
+  "description": "Zucchini, a variety of summer squash (Cucurbita pepo), is a long, typically green fruit harvested when immature. It has a mild flavor, tender skin, and soft, edible seeds. It's highly versatile in cooking and often treated as a vegetable.",
+  "origin": "Ancestors native to Mesoamerica; modern zucchini varieties were developed in Italy in the late 19th century.",
+  "localNames": [
+    "Courgette (French, British English)",
+    "Baby Marrow (South African English)",
+    "Italian Squash (common term)"
+  ],
+  "regions": [
+    "Worldwide; major producers include China, India, United States, Spain, Turkey, Mexico, Italy, Egypt."
+  ],
+  "seasons": [
+    "Primarily Summer in temperate climates when field-grown. Available year-round in many places due to greenhouse cultivation and imports from regions with different growing seasons."
+  ],
+  "nutrition": {
+    "calories": "15 kcal per 100g (cooked, boiled, drained)",
+    "macronutrients": [
+      {
+        "name": "Protein",
+        "value": 1.14,
+        "unit": "g"
+      },
+      {
+        "name": "Carbohydrates",
+        "value": 2.69,
+        "unit": "g"
+      },
+      {
+        "name": "Fat",
+        "value": 0.36,
+        "unit": "g"
+      },
+      {
+        "name": "Fiber",
+        "value": 1.0,
+        "unit": "g"
+      }
+    ],
+    "vitamins": [
+      {
+        "name": "Vitamin C",
+        "value": 12.9,
+        "unit": "mg",
+        "rdi": "14%"
+      },
+      {
+        "name": "Vitamin A",
+        "value": 56,
+        "unit": "µg RAE",
+        "rdi": "6%"
+      },
+      {
+        "name": "Vitamin B6",
+        "value": 0.08,
+        "unit": "mg",
+        "rdi": "5%"
+      },
+      {
+        "name": "Folate (B9)",
+        "value": 28,
+        "unit": "µg",
+        "rdi": "7%"
+      },
+      {
+        "name": "Vitamin K",
+        "value": 4.2,
+        "unit": "µg",
+        "rdi": "3%"
+      }
+    ],
+    "minerals": [
+      {
+        "name": "Potassium",
+        "value": 264,
+        "unit": "mg",
+        "rdi": "6%"
+      },
+      {
+        "name": "Manganese",
+        "value": 0.173,
+        "unit": "mg",
+        "rdi": "8%"
+      },
+      {
+        "name": "Magnesium",
+        "value": 19,
+        "unit": "mg",
+        "rdi": "5%"
+      },
+      {
+        "name": "Phosphorus",
+        "value": 37,
+        "unit": "mg",
+        "rdi": "3%"
+      }
+    ]
+  },
+  "healthBenefits": [
+    "Low in calories and high in water content, making it hydrating and suitable for weight management.",
+    "Good source of Vitamin C and Vitamin A (as carotenoids), which support immune function and vision.",
+    "Provides minerals like potassium and manganese, important for various bodily functions."
+  ],
+  "potentialAllergies": [
+    {
+      "name": "Cucurbitacin sensitivity (rare)",
+      "severity": "Mild to Moderate",
+      "details": "Zucchini can occasionally contain higher levels of cucurbitacins, especially if stressed during growth or cross-pollinated with ornamental gourds, leading to a bitter taste and potential digestive upset. Cultivated varieties are bred for low cucurbitacin levels."
+    },
+    {
+      "name": "Oral Allergy Syndrome (rare)",
+      "severity": "Mild",
+      "details": "Individuals with ragweed pollen allergies may rarely experience OAS symptoms (itching in mouth/throat) from raw zucchini."
+    }
+  ],
+  "cultivationProcess": "Zucchini is a warm-season annual crop, typically grown from seed planted directly into well-drained soil after the last frost. It prefers full sun and rich soil with consistent moisture. Plants are vining or bushy, and flowers require pollination by bees to set fruit. Fruits are harvested while immature, before the skin and seeds harden. Regular harvesting encourages continued fruit production.",
+  "growthDuration": "Typically 40-60 days from sowing to first harvest. Plants can continue producing for several weeks if regularly picked. Overmature fruits (marrows) are much larger and have tougher skin and seeds.",
+  "sustainabilityTips": [
+    "Zucchini plants are often highly productive in home gardens, making them an excellent choice for local food sourcing and reducing food miles.",
+    "The flowers are also edible ('squash blossoms') and can be harvested, utilizing more of the plant and potentially controlling overproduction of fruit."
+  ],
+  "carbonFootprintInfo": "Locally grown zucchini, especially during its peak summer season, has a relatively low carbon footprint. However, out-of-season zucchini that is transported long distances or grown in heated greenhouses will have a significantly higher environmental impact due to energy consumption for transport and climate control.",
+  "staticRecipes": [
+    {
+      "name": "Simple Grilled Zucchini",
+      "description": "A quick and easy way to prepare zucchini that brings out its natural mild sweetness with a delightful smoky char from the grill. A perfect summer side dish.",
+      "ingredients": [
+        "2 medium zucchinis (about 500g or 1 lb total)",
+        "1-2 tablespoons olive oil",
+        "Salt to taste",
+        "Freshly ground black pepper to taste",
+        "Optional: 1/2 teaspoon dried Italian herbs or garlic powder"
+      ],
+      "steps": [
+        "Prepare the zucchini: Wash the zucchinis thoroughly and trim off both ends. Slice them either lengthwise into planks about 1/4 to 1/2 inch (0.5 to 1 cm) thick, or crosswise into thick rounds of similar thickness.",
+        "Preheat your grill (outdoor or indoor grill pan) to medium-high heat.",
+        "Season the zucchini: In a medium bowl, toss the zucchini slices gently with the olive oil. Season with salt, freshly ground black pepper, and any optional dried herbs or garlic powder until they are evenly coated.",
+        "Grill the zucchini: Place the seasoned zucchini slices directly onto the hot grill grates in a single layer. Be careful not to overcrowd the grill; cook in batches if necessary.",
+        "Grill for about 3-5 minutes per side. The cooking time will vary depending on the thickness of your slices and the heat of your grill. Look for tender zucchini with characteristic grill marks and a slight char.",
+        "Avoid overcooking, as zucchini can become mushy if grilled for too long.",
+        "Remove the grilled zucchini from the grill and arrange on a serving platter.",
+        "Serve immediately while warm. You can garnish with fresh chopped parsley or a squeeze of fresh lemon juice if desired."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This commit introduces new JSON files for a comprehensive list of fruits and vegetables that were previously missing. Each file includes detailed information such as:
- Common and scientific names
- A direct HTTPS image URL
- Description, origin, local names, regions, and seasons
- Nutritional information (calories, macronutrients, vitamins, minerals with RDIs)
- Health benefits and potential allergies
- Cultivation process and growth duration
- Sustainability tips and carbon footprint information
- A sample static recipe

The new fruit files are: blackcurrant, longan, mangosteen, rambutan, gooseberry, karonda, noni-fruit, loquat, rose-apple, langsat, sapodilla, persimmon, and surinam-cherry, all added to `src/lib/data/fruits/`.

The new vegetable files are: young-jackfruit (for jackfruit-raw), corn, lettuce, kale, zucchini, kohlrabi, amaranth-leaves, curry-leaves, spring-onion, ivy-gourd, and lotus-stem, all added to `src/lib/data/vegetables/`.

The structure of these new files is consistent with existing data files in the repository (apple.json for fruits, carrot.json for vegetables). All image links provided are direct HTTPS URLs.