### PR TITLE
Fix: Correct camera preview clearing and button states

### DIFF
--- a/src/components/layout/ScanFAB.tsx
+++ b/src/components/layout/ScanFAB.tsx
@@ -1,4 +1,0 @@
-
-// This file is no longer needed as the Scan FAB functionality is moved to the MobileBottomNav.
-// You can safely delete this file from your project.
-// Intentionally left blank for the system to delete.


### PR DESCRIPTION
This commit addresses issues in the ImageUploadForm component:

1.  The "Clear Preview" (X) button in camera mode now correctly clears the current preview and re-activates the camera feed, allowing you to easily retake a photo. Previously, this button was either disabled or would incorrectly re-initiate the capture process.
2.  The disabled logic for the central shutter/upload button has been updated to ensure the "Clear Preview" (X) button is active when a preview is shown and the system is not loading.

Additionally, the obsolete file `src/components/layout/ScanFAB.tsx` has been removed as its functionality was previously consolidated into `MobileBottomNav.tsx`.