### PR TITLE
feat: Add home tab to navigation and blank home page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,42 +1,32 @@
 'use client';
 
-import { useEffect } from 'react';
-import { useRouter } from 'next/navigation';
-import PersonalizedGrowPlanner from '@/components/homefeatures/PersonalizedGrowPlanner';
-import StepByStepGuides from '@/components/homefeatures/StepByStepGuides';
-import SmartCalendarReminders from '@/components/homefeatures/SmartCalendarReminders';
-import PlantGrowthTracker from '@/components/homefeatures/PlantGrowthTracker';
-import PlantHealthScanner from '@/components/homefeatures/PlantHealthScanner';
-import SeedToHarvestTimeline from '@/components/homefeatures/SeedToHarvestTimeline';
-import CommunityFeatures from '@/components/homefeatures/CommunityFeatures';
-import LearnSection from '@/components/homefeatures/LearnSection';
-import MyPlantsOverview from '@/components/homefeatures/MyPlantsOverview';
+// Imports for components are removed as they are no longer used.
+// import { useEffect } from 'react'; // Removed as useEffect is no longer used
+// import { useRouter } from 'next/navigation'; // Removed as useRouter is no longer used
+// import PersonalizedGrowPlanner from '@/components/homefeatures/PersonalizedGrowPlanner';
+// import StepByStepGuides from '@/components/homefeatures/StepByStepGuides';
+// import SmartCalendarReminders from '@/components/homefeatures/SmartCalendarReminders';
+// import PlantGrowthTracker from '@/components/homefeatures/PlantGrowthTracker';
+// import PlantHealthScanner from '@/components/homefeatures/PlantHealthScanner';
+// import SeedToHarvestTimeline from '@/components/homefeatures/SeedToHarvestTimeline';
+// import CommunityFeatures from '@/components/homefeatures/CommunityFeatures';
+// import LearnSection from '@/components/homefeatures/LearnSection';
+// import MyPlantsOverview from '@/components/homefeatures/MyPlantsOverview';
 
 export default function HomePage() {
-  const router = useRouter();
+  // const router = useRouter(); // Removed as useRouter is no longer used
 
-  useEffect(() => {
+  // useEffect(() => { // Removed as per requirement
     // Optional: Redirect to the new search page if the home page should not be accessed directly.
     // Or, if it should be blank but accessible, remove this redirect.
     // For now, let's assume it should be blank and accessible.
     // If a redirect is desired, uncomment the following line:
     // router.replace('/search');
-  }, [router]);
+  // }, [router]);
 
   return (
     <div className="flex flex-col items-center min-h-screen p-4">
-      <h1 className="text-3xl font-bold mb-8 text-center">Welcome to AgriPedia!</h1>
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 w-full max-w-6xl">
-        <PersonalizedGrowPlanner />
-        <StepByStepGuides />
-        <SmartCalendarReminders />
-        <PlantGrowthTracker />
-        <PlantHealthScanner />
-        <SeedToHarvestTimeline />
-        <CommunityFeatures />
-        <LearnSection />
-        <MyPlantsOverview />
-      </div>
+      {/* Content removed to make it a blank page */}
     </div>
   );
 }

--- a/src/components/layout/DesktopSidebar.tsx
+++ b/src/components/layout/DesktopSidebar.tsx
@@ -38,6 +38,13 @@ export default function DesktopSidebar() {
       </SidebarHeader>
       <SidebarContent>
         <SidebarMenu>
+          <SidebarMenuItem>
+            <Link href="/" legacyBehavior passHref>
+              <SidebarMenuButton asChild tooltip="Home" className="text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground">
+                <a><Home /> <span>Home</span></a>
+              </SidebarMenuButton>
+            </Link>
+          </SidebarMenuItem>
           {/* Removed Home MenuItem */}
           <SidebarMenuItem>
             <Link href="/chat" legacyBehavior passHref>

--- a/src/components/layout/MobileBottomNav.tsx
+++ b/src/components/layout/MobileBottomNav.tsx
@@ -2,7 +2,7 @@
 'use client';
 
 import Link from 'next/link';
-import { Leaf, ScanLine, Settings as SettingsIcon, MessagesSquare, Heart, Search } from 'lucide-react';
+import { Home, Leaf, ScanLine, Settings as SettingsIcon, MessagesSquare, Heart, Search } from 'lucide-react';
 import { Dialog, DialogContent, DialogTitle, DialogClose } from '@/components/ui/dialog'; // Added DialogTitle and DialogClose
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
 import ImageUploadForm from '@/components/search/ImageUploadForm';
@@ -57,6 +57,7 @@ export default function MobileBottomNav() {
   const pathname = usePathname();
 
   const navItemsConfig = [
+    { id: "home", href: "/", icon: Home, label: "Home" },
     // { id: "home", href: "/", icon: Leaf, label: "Home" }, // Removed Home
     { id: "chat", href: "/chat", icon: MessagesSquare, label: "Chat AI" },
     {


### PR DESCRIPTION
Adds a 'Home' tab to both the desktop sidebar and mobile bottom navigation. The home tab is now the first item in both navigation components and links to '/'.

The content of the home page at `src/app/page.tsx` has been removed, making it a blank page as per your request. The potential redirect logic has also been removed from this page.