### PR TITLE
Update card backgrounds to match AI Garden Design Assistant

### DIFF
--- a/src/components/homefeatures/AITips.tsx
+++ b/src/components/homefeatures/AITips.tsx
@@ -15,7 +15,7 @@ export default function AITips() {
 
   return (
     <motion.div variants={itemVariants}>
-      <Card className="h-full flex flex-col group hover:shadow-xl transition-shadow duration-300 ease-in-out">
+      <Card className="h-full flex flex-col group hover:shadow-xl transition-shadow duration-300 ease-in-out bg-gradient-to-br from-primary/10 via-transparent to-transparent">
         <CardHeader>
           <div className="flex items-start gap-3">
             <Sparkles size={24} className="shrink-0 text-primary mt-1 group-hover:animate-ping once" />

--- a/src/components/homefeatures/CommunityFeatures.tsx
+++ b/src/components/homefeatures/CommunityFeatures.tsx
@@ -3,7 +3,7 @@ import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/com
 
 export default function CommunityFeatures() {
   return (
-    <Card className="rounded-2xl h-full flex flex-col group hover:shadow-xl transition-shadow duration-300 ease-in-out">
+    <Card className="rounded-2xl h-full flex flex-col group hover:shadow-xl transition-shadow duration-300 ease-in-out bg-gradient-to-br from-primary/10 via-transparent to-transparent">
       <CardHeader>
         <CardTitle className="font-serif">Community Features</CardTitle>
       </CardHeader>

--- a/src/components/homefeatures/DiseasePrediction.tsx
+++ b/src/components/homefeatures/DiseasePrediction.tsx
@@ -20,7 +20,7 @@ export default function DiseasePrediction() {
 
   return (
     <motion.div variants={itemVariants}>
-      <Card className="h-full flex flex-col group hover:shadow-xl transition-shadow duration-300 ease-in-out">
+      <Card className="h-full flex flex-col group hover:shadow-xl transition-shadow duration-300 ease-in-out bg-gradient-to-br from-primary/10 via-transparent to-transparent">
         <CardHeader>
           <div className="flex items-start gap-3">
             <ScanLine size={24} className="shrink-0 text-primary mt-1 group-hover:animate-pulse transition-transform duration-300" />

--- a/src/components/homefeatures/LearnSection.tsx
+++ b/src/components/homefeatures/LearnSection.tsx
@@ -3,7 +3,7 @@ import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/com
 
 export default function LearnSection() {
   return (
-    <Card className="rounded-2xl h-full flex flex-col group hover:shadow-xl transition-shadow duration-300 ease-in-out">
+    <Card className="rounded-2xl h-full flex flex-col group hover:shadow-xl transition-shadow duration-300 ease-in-out bg-gradient-to-br from-primary/10 via-transparent to-transparent">
       <CardHeader>
         <CardTitle className="font-serif">Learn Section</CardTitle>
       </CardHeader>

--- a/src/components/homefeatures/MyPlantsOverview.tsx
+++ b/src/components/homefeatures/MyPlantsOverview.tsx
@@ -5,7 +5,7 @@ import { Leaf } from 'lucide-react';
 
 export default function MyPlantsOverview() {
   return (
-    <Card className="rounded-2xl h-full flex flex-col group hover:shadow-xl transition-shadow duration-300 ease-in-out">
+    <Card className="rounded-2xl h-full flex flex-col group hover:shadow-xl transition-shadow duration-300 ease-in-out bg-gradient-to-br from-primary/10 via-transparent to-transparent">
       <CardHeader className="flex flex-row items-center gap-3">
         <Leaf size={28} className="text-primary group-hover:animate-sprout origin-bottom transition-transform duration-300" />
         <CardTitle className="font-serif">My Plants Overview</CardTitle>


### PR DESCRIPTION
This commit applies a new background gradient style to several card components in the home tab. The goal is to make their appearance consistent with the "AI Garden Design Assistant" card.

The following components were updated:

- AITips.tsx
- CommunityFeatures.tsx
- DiseasePrediction.tsx
- LearnSection.tsx
- MyPlantsOverview.tsx

The PersonalizedGrowPlanner.tsx component was identified as not using the standard Card component. I updated my approach to modify its main div container directly.

Based on your feedback, I intend to cover all identified card components. The remaining components that should have this style applied are:

- PersonalizedGrowPlanner.tsx (updated approach)
- PlantGrowthTracker.tsx
- PlantHealthScanner.tsx
- SeedToHarvestTimeline.tsx
- SmartCalendarReminders.tsx
- SmartPlantRecommender.tsx
- StepByStepGuides.tsx

The new background style uses the following Tailwind CSS classes: `bg-gradient-to-br from-primary/10 via-transparent to-transparent`